### PR TITLE
update:

### DIFF
--- a/bootstrap/variables.tf
+++ b/bootstrap/variables.tf
@@ -68,6 +68,7 @@ variable "project_services_fleet" {
     "gkeonprem.googleapis.com",
     "iam.googleapis.com",
     "iamcredentials.googleapis.com",
+    "kubernetesmetadata.googleapis.com",
     "logging.googleapis.com",
     "monitoring.googleapis.com",
     "opsconfigmonitoring.googleapis.com",


### PR DESCRIPTION
- 1.8.0 will require kubernetesmetadata.googleapis.com per https://cloud.google.com/distributed-cloud/edge/latest/docs/release-notes