### PR TITLE
Group rbac update using clientconfig

### DIFF
--- a/bootstrap/create-cluster.yaml
+++ b/bootstrap/create-cluster.yaml
@@ -244,8 +244,11 @@ steps:
     gcloud beta container fleet config-management apply --membership=$CLUSTER_NAME \
         --config=./apply-spec.yaml --project $FLEET_PROJECT_ID
 
-    if [ -z "${SKIP_IDENTITY_SERVICE}" ]; then
+    if [[ "${SKIP_IDENTITY_SERVICE}" == "FALSE" ]]; then
       kubectl patch clientconfig default -n kube-public --type=merge -p '{"spec":{"authentication":[{"google":{"audiences":["//'${GKEHUB_API_ENDPOINT}'/projects/'${FLEET_PROJECT_ID}'/locations/global/memberships/'${CLUSTER_NAME}'"]},"name":"google-authentication-method"}]}}'
+      echo "Group RBAC applied"
+    else
+      echo "Skipping Group RBAC setup"
     fi
 
     set +eE

--- a/bootstrap/create-cluster.yaml
+++ b/bootstrap/create-cluster.yaml
@@ -244,8 +244,9 @@ steps:
     gcloud beta container fleet config-management apply --membership=$CLUSTER_NAME \
         --config=./apply-spec.yaml --project $FLEET_PROJECT_ID
 
+    FLEET_PROJECT_NUMBER=$(gcloud projects describe cloud-alchemists-sandbox --format='value(projectNumber)')
     if [[ "${SKIP_IDENTITY_SERVICE}" == "FALSE" ]]; then
-      kubectl patch clientconfig default -n kube-public --type=merge -p '{"spec":{"authentication":[{"google":{"audiences":["//'${GKEHUB_API_ENDPOINT}'/projects/'${FLEET_PROJECT_ID}'/locations/global/memberships/'${CLUSTER_NAME}'"]},"name":"google-authentication-method"}]}}'
+      kubectl patch clientconfig default -n kube-public --type=merge -p '{"spec":{"authentication":[{"google":{"audiences":["//'${GKEHUB_API_ENDPOINT}'/projects/'${FLEET_PROJECT_NUMBER}'/locations/global/memberships/'${CLUSTER_NAME}'"]},"name":"google-authentication-method"}]}}'
       echo "Group RBAC applied"
     else
       echo "Skipping Group RBAC setup"

--- a/bootstrap/create-cluster.yaml
+++ b/bootstrap/create-cluster.yaml
@@ -133,9 +133,13 @@ steps:
       gcloud config set api_endpoint_overrides/edgecontainer $EDGE_CONTAINER_API_ENDPOINT_OVERRIDE
     fi
 
+
     if [ -n "${GKEHUB_API_ENDPOINT_OVERRIDE:-}" ]; then
       echo "Setting api_endpoint_overrides/gkehub to $GKEHUB_API_ENDPOINT_OVERRIDE"
       gcloud config set api_endpoint_overrides/gkehub $GKEHUB_API_ENDPOINT_OVERRIDE
+      GKEHUB_API_ENDPOINT="staging-gkehub.sandbox.googleapis.com"
+    else
+      GKEHUB_API_ENDPOINT="gkehub.googleapis.com"
     fi
 
     if [ -n "${EDGE_NETWORK_API_ENDPOINT_OVERRIDE:-}" ]; then
@@ -241,7 +245,7 @@ steps:
         --config=./apply-spec.yaml --project $FLEET_PROJECT_ID
 
     if [ -z "${SKIP_IDENTITY_SERVICE}" ]; then
-      kubectl patch clientconfig default -n kube-public --type=merge -p '{"spec":{"authentication":[{"google":{"audiences":["//'${GKEHUB_API_ENDPOINT_OVERRIDE}'/projects/'${FLEET_PROJECT_ID}'/locations/global/memberships/'${CLUSTER_NAME}'"]},"name":"google-authentication-method"}]}}'
+      kubectl patch clientconfig default -n kube-public --type=merge -p '{"spec":{"authentication":[{"google":{"audiences":["//'${GKEHUB_API_ENDPOINT}'/projects/'${FLEET_PROJECT_ID}'/locations/global/memberships/'${CLUSTER_NAME}'"]},"name":"google-authentication-method"}]}}'
     fi
 
     set +eE

--- a/bootstrap/create-cluster.yaml
+++ b/bootstrap/create-cluster.yaml
@@ -105,7 +105,6 @@ steps:
     export CLUSTER_INTENT_HEADER=$(head -1 cluster-intent-registry.csv)
     export CLUSTER_INTENT="$CLUSTER_INTENT_HEADER"$'\n'"$CLUSTER_INTENT_ROW"
 
-
     # Set parameters from cluster intent
     export MACHINE_PROJECT_ID=$(parse_csv_required "$CLUSTER_INTENT" "machine_project_id")
     export FLEET_PROJECT_ID=$(parse_csv_required "$CLUSTER_INTENT" "fleet_project_id")
@@ -132,7 +131,6 @@ steps:
       echo "Setting api_endpoint_overrides/edgecontainer to $EDGE_CONTAINER_API_ENDPOINT_OVERRIDE"
       gcloud config set api_endpoint_overrides/edgecontainer $EDGE_CONTAINER_API_ENDPOINT_OVERRIDE
     fi
-
 
     if [ -n "${GKEHUB_API_ENDPOINT_OVERRIDE:-}" ]; then
       echo "Setting api_endpoint_overrides/gkehub to $GKEHUB_API_ENDPOINT_OVERRIDE"
@@ -244,8 +242,8 @@ steps:
     gcloud beta container fleet config-management apply --membership=$CLUSTER_NAME \
         --config=./apply-spec.yaml --project $FLEET_PROJECT_ID
 
-    FLEET_PROJECT_NUMBER=$(gcloud projects describe $FLEET_PROJECT_ID --format='value(projectNumber)')
     if [[ "${SKIP_IDENTITY_SERVICE}" == "FALSE" ]]; then
+      FLEET_PROJECT_NUMBER=$(gcloud projects describe $FLEET_PROJECT_ID --format='value(projectNumber)')
       kubectl patch clientconfig default -n kube-public --type=merge -p '{"spec":{"authentication":[{"google":{"audiences":["//'${GKEHUB_API_ENDPOINT}'/projects/'${FLEET_PROJECT_NUMBER}'/locations/global/memberships/'${CLUSTER_NAME}'"]},"name":"google-authentication-method"}]}}'
       echo "Group RBAC applied"
     else

--- a/bootstrap/create-cluster.yaml
+++ b/bootstrap/create-cluster.yaml
@@ -244,7 +244,7 @@ steps:
     gcloud beta container fleet config-management apply --membership=$CLUSTER_NAME \
         --config=./apply-spec.yaml --project $FLEET_PROJECT_ID
 
-    FLEET_PROJECT_NUMBER=$(gcloud projects describe cloud-alchemists-sandbox --format='value(projectNumber)')
+    FLEET_PROJECT_NUMBER=$(gcloud projects describe $FLEET_PROJECT_ID --format='value(projectNumber)')
     if [[ "${SKIP_IDENTITY_SERVICE}" == "FALSE" ]]; then
       kubectl patch clientconfig default -n kube-public --type=merge -p '{"spec":{"authentication":[{"google":{"audiences":["//'${GKEHUB_API_ENDPOINT}'/projects/'${FLEET_PROJECT_NUMBER}'/locations/global/memberships/'${CLUSTER_NAME}'"]},"name":"google-authentication-method"}]}}'
       echo "Group RBAC applied"

--- a/bootstrap/create-cluster.yaml
+++ b/bootstrap/create-cluster.yaml
@@ -241,10 +241,7 @@ steps:
         --config=./apply-spec.yaml --project $FLEET_PROJECT_ID
 
     if [ -z "${SKIP_IDENTITY_SERVICE}" ]; then
-      gcloud container fleet identity-service enable --project $FLEET_PROJECT_ID
-
-      gcloud container fleet identity-service apply --membership=$CLUSTER_NAME \
-          --config=./auth-config.yaml --project $FLEET_PROJECT_ID
+      kubectl patch clientconfig default -n kube-public --type=merge -p '{"spec":{"authentication":[{"google":{"audiences":["//'${GKEHUB_API_ENDPOINT_OVERRIDE}'/projects/'${FLEET_PROJECT_ID}'/locations/global/memberships/'${CLUSTER_NAME}'"]},"name":"google-authentication-method"}]}}'
     fi
 
     set +eE

--- a/bootstrap/main.tf
+++ b/bootstrap/main.tf
@@ -28,7 +28,7 @@ locals {
     { _GIT_SECRETS_PROJECT_ID = local.project_id_secrets },
     { _TIMEOUT_IN_SECONDS = var.cluster-creation-timeout },
     { _CS_VERSION = var.default-config-sync-version },
-    var.skip_identity_service ? { _SKIP_IDENTITY_SERVICE = "TRUE" } : {},
+    var.skip_identity_service == true ? { _SKIP_IDENTITY_SERVICE = "TRUE" } : {_SKIP_IDENTITY_SERVICE = "FALSE"},
     var.bart_create_bucket == true ? { _BART_CREATE_BUCKET = "TRUE" } : { _BART_CREATE_BUCKET = "FALSE" },
   )
   project_id_fleet   = coalesce(var.project_id_fleet, var.project_id)


### PR DESCRIPTION
https://pantheon.corp.google.com/cloud-build/builds;region=us-central1/4f2faeb3-9333-4e1c-bf04-f7e672312648?e=off&inv=1&invt=AbsYBw&mods=off&project=cloud-alchemists-sandbox

```
gcloud container fleet memberships get-credentials gmec-den66
Fetching Gateway kubeconfig...
A new kubeconfig entry "connectgateway_gdc-solutions-customer-sim_global_gmec-den66" has been generated and set as the current context.

$ k get nodes
NAME                           STATUS   ROLES           AGE    VERSION
gmec-den6601.ba.l.google.com   Ready    control-plane   145d   v1.28.10-gke.2100
gmec-den6602.ba.l.google.com   Ready    control-plane   145d   v1.28.10-gke.2100
gmec-den6603.ba.l.google.com   Ready    control-plane   145d   v1.28.10-gke.2100```