### PR TITLE
Add the ability to automatically retry failed builds

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,7 @@ This solution automates the provisioning and configuration of Google Distributed
   - [Operations](#operations)
     - [Metrics](#metrics)
     - [Alerts](#alerts)
+    - [Automated Retries](#automated-retries)
   - [Terraform Details](#terraform-details)
     - [Providers](#providers)
     - [Modules](#modules)
@@ -167,6 +168,13 @@ This table describes the alerts created to monitoring cluster provisioning. Thes
 | unknown-zone-alert       | Alerts whenever an unknown zone not defined in the cluster intent source of truth has been found in the environment. |
 | cluster-creation-failure | Alerts when cluster creation has failed                                                                              |
 | cluster-modify-failure   | Alerts when cluster modification has failed                                                                          |
+
+### Automated Retries
+
+Automated retries can be configured to address intermittent build failures. To enable, set the `cluster-creation-max-retries` variable in the terraform to a value greater than 0 but less than 5. The solution tracks the number of failed builds for a zone and will retry them until the number exceeds the specified max retry.
+
+> [!Note]
+> If you decrease the number of `cluster-creation-max-retries`, this may impact in-progress builds from properly calling the [zone's signal endpoint](https://cloud.google.com/distributed-cloud/edge/latest/docs/reference/hardware/rest/v1alpha/projects.locations.zones/signal) properly. Be sure to manually check that any failed builds are properly retried. This is not a concern when increasing the value.
 
 ## Terraform Details
 

--- a/bootstrap/create-cluster.yaml
+++ b/bootstrap/create-cluster.yaml
@@ -31,7 +31,22 @@ steps:
     function die() {
       echo "$1"
       echo "Cluster Creation Failed: $CLUSTER_NAME"
-      zone_signal "projects/${MACHINE_PROJECT_ID}/locations/${LOCATION}/zones/${STORE_ID}" FACTORY_TURNUP_CHECKS_FAILED
+
+      if [[ "$MAX_RETRIES" -eq 0 ]]; then
+        echo "Marking zone as failed"
+        zone_signal "projects/${MACHINE_PROJECT_ID}/locations/${LOCATION}/zones/${STORE_ID}" FACTORY_TURNUP_CHECKS_FAILED
+      else
+        # Will include the current build as well
+        BUILD_COUNT=$(gcloud builds list --filter "tags='$STORE_ID' AND substitutions.TRIGGER_NAME='$TRIGGER_NAME'" --region us-central1 --format="csv[no-heading](name)" | wc -l)
+
+        if [[ "$BUILD_COUNT" -gt "$MAX_RETRIES" ]]; then
+          echo "Current build count $BUILD_COUNT exceed max retries $MAX_RETRIES. Marking zone as failed"
+          zone_signal "projects/${MACHINE_PROJECT_ID}/locations/${LOCATION}/zones/${STORE_ID}" FACTORY_TURNUP_CHECKS_FAILED
+        else
+          echo "Current build count $BUILD_COUNT is <= max retries $MAX_RETRIES. Skipping for next retry"
+        fi
+      fi
+
       exit 1
     }
 
@@ -333,6 +348,8 @@ steps:
   - 'ZONE=$_ZONE'
   - 'CS_VERSION=$_CS_VERSION'
   - 'BART_CREATE_BUCKET=$_BART_CREATE_BUCKET'
+  - 'MAX_RETRIES=$_MAX_RETRIES'
+  - 'TRIGGER_NAME=$TRIGGER_NAME'
 
 options:
   logging: CLOUD_LOGGING_ONLY

--- a/bootstrap/main.tf
+++ b/bootstrap/main.tf
@@ -28,6 +28,7 @@ locals {
     { _GIT_SECRETS_PROJECT_ID = local.project_id_secrets },
     { _TIMEOUT_IN_SECONDS = var.cluster-creation-timeout },
     { _CS_VERSION = var.default-config-sync-version },
+    { _MAX_RETRIES = var.cluster-creation-max-retries },
     var.skip_identity_service == true ? { _SKIP_IDENTITY_SERVICE = "TRUE" } : {_SKIP_IDENTITY_SERVICE = "FALSE"},
     var.bart_create_bucket == true ? { _BART_CREATE_BUCKET = "TRUE" } : { _BART_CREATE_BUCKET = "FALSE" },
   )
@@ -179,6 +180,12 @@ resource "google_project_iam_member" "gdce-provisioning-agent-storage-admin" {
 resource "google_project_iam_member" "gdce-provisioning-agent-log-writer" {
   project = var.project_id
   role    = "roles/logging.logWriter"
+  member  = google_service_account.gdce-provisioning-agent.member
+}
+
+resource "google_project_iam_member" "gdce-provisioning-agent-build-viewer" {
+  project = var.project_id
+  role    = "roles/cloudbuild.builds.viewer"
   member  = google_service_account.gdce-provisioning-agent.member
 }
 

--- a/bootstrap/variables.tf
+++ b/bootstrap/variables.tf
@@ -152,6 +152,12 @@ variable "cluster-creation-timeout" {
   type        = number
 }
 
+variable "cluster-creation-max-retries" {
+  description = "The maximum number of retries upon cluster creation failure before marking the zone state as CUSTOMER_FACTORY_TURNUP_CHECKS_FAILED"
+  default     = "0"
+  type        = number
+}
+
 # https://cloud.google.com/kubernetes-engine/enterprise/config-sync/docs/release-notes
 variable "default-config-sync-version" {
   description = "Sets a default ConfigSync version to use for provisioned clusters. If left empty, it will not specify a version at the cluster level. If empty, this will either install the fleet configured version or the latest version of ConfigSync."

--- a/watchers/src/build_history.py
+++ b/watchers/src/build_history.py
@@ -1,0 +1,154 @@
+import logging
+import os
+from google.cloud.devtools import cloudbuild
+from google.cloud.devtools.cloudbuild import Build
+from typing import Dict
+
+logger = logging.getLogger(__name__)
+logger.setLevel(os.environ.get("LOG_LEVEL", "INFO").upper())
+
+class BuildSummary:
+    latestStatus: Build.Status = None
+    numberOfBuilds: int = 0
+    numberOfFailures: int = 0
+    retriable: bool = False
+
+    def add_build(self, build: cloudbuild.Build):
+        self.numberOfBuilds += 1
+
+        if build.status not in (
+            cloudbuild.Build.Status.QUEUED,
+            cloudbuild.Build.Status.PENDING,
+            cloudbuild.Build.Status.WORKING,
+            cloudbuild.Build.Status.SUCCESS):
+            self.numberOfFailures += 1
+
+        # This means that there is a build in progress and we should not retry or change the status
+        if self.latestStatus in (cloudbuild.Build.Status.QUEUED, cloudbuild.Build.Status.PENDING, cloudbuild.Build.Status.WORKING):
+            self.retriable = False
+            return
+
+        # This means that there was a successful build and we should not retry
+        if self.latestStatus == cloudbuild.Build.Status.SUCCESS:
+            self.retriable = False
+            return
+        
+        if build.status in (cloudbuild.Build.Status.QUEUED, cloudbuild.Build.Status.PENDING, cloudbuild.Build.Status.WORKING):
+            self.latestStatus = build.status
+            self.retriable = False
+        elif build.status == cloudbuild.Build.Status.SUCCESS:
+            self.latestStatus = build.status
+            self.retriable = False
+        else:
+            # Any status in this category can be treated as a failure
+            self.retriable = True
+
+    def is_retriable(self, max_retries: int):
+        if self.numberOfFailures > max_retries:
+            return False
+        
+        return self.retriable
+
+
+class BuildHistory:
+    def __init__(self, project_id: str, region: str, max_retries: int, trigger_name: str):
+        self.project_id = project_id
+        self.region = region
+        self.max_retries = max_retries
+        self.trigger_name = trigger_name
+        self.client = cloudbuild.CloudBuildClient()
+        self.builds: Dict[str, BuildSummary] = None
+
+    def _get_build_history(self) ->Dict[str, BuildSummary]:
+        """
+        Queries for Cloud Build history matching a specific trigger name.
+
+        Args:
+            trigger_name: The name of the Cloud Build trigger.
+
+        Returns:
+            A dictionary with the zone name as the key and the build summary
+            which contains relevant information to determine if a retry should
+            be triggered.
+        """
+        trigger_request = cloudbuild.ListBuildTriggersRequest(
+            project_id = self.project_id,
+            parent = f"projects/{self.project_id}/locations/{self.region}"
+        )
+
+        trigger_name_filter = ""
+
+        triggers = self.client.list_build_triggers(trigger_request)
+
+        if len(triggers) == 0:
+            raise Exception(f"No triggers found named {self.trigger_name}")
+
+        for trigger in triggers:
+            if (trigger.name == self.trigger_name):
+                if trigger_name_filter == "":
+                    trigger_name_filter += f"trigger_id={trigger.id}"
+                else:
+                    trigger_name_filter += f" OR trigger_id={trigger.id}"
+
+        request = cloudbuild.ListBuildsRequest(
+            project_id=self.project_id,
+            filter=trigger_name_filter,
+            parent = f"projects/{self.project_id}/locations/{self.region}"
+        )
+
+        page_result = self.client.list_builds(request=request)
+
+        # Only page through last 1,000 builds
+        build_entries = 0
+        build_summary_dict: Dict[str, BuildSummary] = dict()
+
+        for response in page_result:
+            build_entries += 1
+
+            if build_entries > 1000:
+                break
+
+            zone = ""
+
+            for key in response.substitutions:
+                if key == "_ZONE":
+                    zone = response.substitutions[key]
+
+            if not zone:
+                # Builds are expected to have the _ZONE substitution. This is the value that is
+                # matched on to calculate whether a build should be retried or not. 
+                logging.warning(f"build found within _ZONE substitution, skipping... Build ID: {response.id}")
+                continue
+
+            if zone in build_summary_dict:
+                summary = build_summary_dict[zone]
+                summary.add_build(response)
+            else:
+                summary = BuildSummary()
+                summary.add_build(response)
+                build_summary_dict[zone] = summary
+
+        return build_summary_dict
+
+    def should_retry_zone_build(self, zone_name: str):
+        """
+        Determines if a build should be retried or not. `False` is returned in the event 
+        of no build history for a zone. 
+
+        Args:
+            zone_name: The name of the zone
+        """
+        if not zone_name:
+            raise Exception('missing zone_name')
+        
+        if self.builds is None:
+            self.builds = self._get_build_history()
+
+        if zone_name not in self.builds:
+            return False
+        else:
+            build = self.builds[zone_name]
+            return build.is_retriable(self.max_retries)
+
+        
+        

--- a/watchers/src/main.py
+++ b/watchers/src/main.py
@@ -177,6 +177,7 @@ def zone_watcher(req: flask.Request):
                     count_of_free_machines = count_of_free_machines+1
 
             if cluster_exists:
+                logger.info(f'Cluster already exists for {zone}. Skipping..')
                 continue
 
             if count_of_free_machines >= int(store_info["node_count"]):

--- a/watchers/tests/test_build_history.py
+++ b/watchers/tests/test_build_history.py
@@ -1,0 +1,371 @@
+import unittest
+from unittest.mock import patch, MagicMock, call
+import os
+from google.cloud.devtools import cloudbuild
+from google.protobuf.timestamp_pb2 import Timestamp
+from google.cloud.devtools.cloudbuild import Build
+
+# Assuming the classes are in a file named 'build_history.py'
+# If not, adjust the import path accordingly
+from src.build_history import BuildHistory, BuildSummary
+
+Status = Build.Status
+
+# Helper to create mock build objects
+def create_mock_build(id, status, substitutions=None, create_time_seconds=0):
+    build = MagicMock(spec=cloudbuild.Build)
+    build.id = id
+    build.status = status
+    build.substitutions = substitutions if substitutions else {}
+    # Add a mock create_time if needed for ordering, though the current logic doesn't sort by time
+    build.create_time = Timestamp(seconds=create_time_seconds)
+    return build
+
+class TestBuildSummary(unittest.TestCase):
+
+    def test_initial_state(self):
+        summary = BuildSummary()
+        self.assertIsNone(summary.latestStatus)
+        self.assertEqual(summary.numberOfBuilds, 0)
+        self.assertEqual(summary.numberOfFailures, 0)
+        self.assertFalse(summary.retriable)
+
+    def test_add_build_success(self):
+        summary = BuildSummary()
+        build = create_mock_build("b1", Status.SUCCESS)
+        summary.add_build(build)
+        self.assertEqual(summary.latestStatus, Status.SUCCESS)
+        self.assertEqual(summary.numberOfBuilds, 1)
+        self.assertEqual(summary.numberOfFailures, 0)
+        self.assertFalse(summary.retriable)
+
+    def test_add_build_failure(self):
+        summary = BuildSummary()
+        build = create_mock_build("b1", Status.FAILURE)
+        summary.add_build(build)
+        # Note: latestStatus isn't updated on failure if it was None initially
+        # self.assertEqual(summary.latestStatus, MockBuildStatus.FAILURE) # This depends on initial state logic
+        self.assertEqual(summary.numberOfBuilds, 1)
+        self.assertEqual(summary.numberOfFailures, 1)
+        self.assertTrue(summary.retriable)
+
+    def test_add_build_working(self):
+        summary = BuildSummary()
+        build = create_mock_build("b1", Status.WORKING)
+        summary.add_build(build)
+        self.assertEqual(summary.latestStatus, Status.WORKING)
+        self.assertEqual(summary.numberOfBuilds, 1)
+        self.assertEqual(summary.numberOfFailures, 0)
+        self.assertFalse(summary.retriable)
+
+    def test_add_build_queued(self):
+        summary = BuildSummary()
+        build = create_mock_build("b1", Status.QUEUED)
+        summary.add_build(build)
+        self.assertEqual(summary.latestStatus, Status.QUEUED)
+        self.assertEqual(summary.numberOfBuilds, 1)
+        self.assertEqual(summary.numberOfFailures, 0)
+        self.assertFalse(summary.retriable)
+
+    def test_add_build_pending(self):
+        summary = BuildSummary()
+        build = create_mock_build("b1", Status.PENDING)
+        summary.add_build(build)
+        self.assertEqual(summary.latestStatus, Status.PENDING)
+        self.assertEqual(summary.numberOfBuilds, 1)
+        self.assertEqual(summary.numberOfFailures, 0)
+        self.assertFalse(summary.retriable)
+
+    def test_add_build_sequence_fail_then_success(self):
+        summary = BuildSummary()
+        build_fail = create_mock_build("b1", Status.FAILURE)
+        build_success = create_mock_build("b2", Status.SUCCESS)
+        summary.add_build(build_fail)
+        summary.add_build(build_success) # Success overrides retriable
+        self.assertEqual(summary.latestStatus, Status.SUCCESS)
+        self.assertEqual(summary.numberOfBuilds, 2)
+        self.assertEqual(summary.numberOfFailures, 1) # Failure count still increments
+        self.assertFalse(summary.retriable)
+
+    def test_add_build_sequence_fail_then_working(self):
+        summary = BuildSummary()
+        build_fail = create_mock_build("b1", Status.FAILURE)
+        build_working = create_mock_build("b2", Status.WORKING)
+        summary.add_build(build_fail)
+        summary.add_build(build_working) # Working overrides retriable
+        self.assertEqual(summary.latestStatus, Status.WORKING)
+        self.assertEqual(summary.numberOfBuilds, 2)
+        self.assertEqual(summary.numberOfFailures, 1)
+        self.assertFalse(summary.retriable)
+
+    def test_add_build_sequence_success_then_fail(self):
+        summary = BuildSummary()
+        build_success = create_mock_build("b1", Status.SUCCESS)
+        build_fail = create_mock_build("b2", Status.FAILURE)
+        summary.add_build(build_success)
+        summary.add_build(build_fail) # Failure after success doesn't change status/retriable
+        self.assertEqual(summary.latestStatus, Status.SUCCESS)
+        self.assertEqual(summary.numberOfBuilds, 2)
+        self.assertEqual(summary.numberOfFailures, 1) # Failure count still increments
+        self.assertFalse(summary.retriable) # Still False because latest was SUCCESS
+
+    def test_add_build_sequence_working_then_fail(self):
+        summary = BuildSummary()
+        build_working = create_mock_build("b1", Status.WORKING)
+        build_fail = create_mock_build("b2", Status.FAILURE)
+        summary.add_build(build_working)
+        summary.add_build(build_fail) # Failure after working doesn't change status/retriable
+        self.assertEqual(summary.latestStatus, Status.WORKING)
+        self.assertEqual(summary.numberOfBuilds, 2)
+        self.assertEqual(summary.numberOfFailures, 1)
+        self.assertFalse(summary.retriable) # Still False because latest was WORKING
+
+    def test_add_build_multiple_failures(self):
+        summary = BuildSummary()
+        build1 = create_mock_build("b1", Status.FAILURE)
+        build2 = create_mock_build("b2", Status.TIMEOUT)
+        summary.add_build(build1)
+        summary.add_build(build2)
+        # self.assertEqual(summary.latestStatus, MockBuildStatus.TIMEOUT) # Status doesn't update on failure if already failed
+        self.assertEqual(summary.numberOfBuilds, 2)
+        self.assertEqual(summary.numberOfFailures, 2)
+        self.assertTrue(summary.retriable)
+
+    def test_is_retriable_false_max_retries_exceeded(self):
+        summary = BuildSummary()
+        build1 = create_mock_build("b1", Status.FAILURE)
+        build2 = create_mock_build("b2", Status.INTERNAL_ERROR)
+        summary.add_build(build1)
+        summary.add_build(build2) # 2 failures
+        self.assertTrue(summary.is_retriable(max_retries=2))
+        self.assertFalse(summary.is_retriable(max_retries=1))
+        self.assertFalse(summary.is_retriable(max_retries=0))
+
+    def test_is_retriable_false_not_retriable_state(self):
+        summary = BuildSummary()
+        build = create_mock_build("b1", Status.SUCCESS)
+        summary.add_build(build)
+        self.assertFalse(summary.is_retriable(max_retries=1))
+
+        summary = BuildSummary()
+        build = create_mock_build("b1", Status.WORKING)
+        summary.add_build(build)
+        self.assertFalse(summary.is_retriable(max_retries=1))
+
+
+@patch('google.cloud.devtools.cloudbuild.CloudBuildClient') # Patch the client in the module where it's used
+class TestBuildHistory(unittest.TestCase):
+
+    def setUp(self):
+        # Set environment variable for logging if needed, though we don't assert logs here
+        os.environ["LOG_LEVEL"] = "DEBUG"
+        self.project_id = "test-project"
+        self.region = "us-central1"
+        self.max_retries = 2
+        self.trigger_name = "my-cool-trigger"
+        self.trigger_id = "trigger-123"
+        self.parent = f"projects/{self.project_id}/locations/{self.region}"
+
+    def tearDown(self):
+        # Clean up environment variables if set
+        if "LOG_LEVEL" in os.environ:
+            del os.environ["LOG_LEVEL"]
+
+    def test_init(self, MockCloudBuildClient):
+        instance = MockCloudBuildClient.return_value
+        history = BuildHistory(self.project_id, self.region, self.max_retries, self.trigger_name)
+        self.assertEqual(history.project_id, self.project_id)
+        self.assertEqual(history.region, self.region)
+        self.assertEqual(history.max_retries, self.max_retries)
+        self.assertEqual(history.trigger_name, self.trigger_name)
+        self.assertIs(history.client, instance)
+        self.assertIsNone(history.builds)
+        MockCloudBuildClient.assert_called_once()
+
+    def test_get_build_history_no_triggers(self, MockCloudBuildClient):
+        mock_client = MockCloudBuildClient.return_value
+        mock_client.list_build_triggers.return_value = [] # No triggers found
+
+        history = BuildHistory(self.project_id, self.region, self.max_retries, self.trigger_name)
+        self.assertRaises(Exception, history._get_build_history)
+
+    def test_get_build_history_no_matching_triggers(self, MockCloudBuildClient):
+        mock_client = MockCloudBuildClient.return_value
+        mock_trigger = MagicMock()
+        mock_trigger.name = "other-trigger-name"
+        mock_trigger.id = "other-id"
+        mock_client.list_build_triggers.return_value = [mock_trigger]
+
+        history = BuildHistory(self.project_id, self.region, self.max_retries, self.trigger_name)
+        build_dict = history._get_build_history()
+
+        self.assertEqual(build_dict, {})
+        mock_client.list_build_triggers.assert_called_once()
+        # Should call list_builds with an empty filter if no matching triggers found
+        mock_client.list_builds.assert_called_once_with(request=cloudbuild.ListBuildsRequest(
+            project_id=self.project_id,
+            filter="", # Empty filter
+            parent=self.parent
+        ))
+
+
+    def test_get_build_history_matching_trigger_no_builds(self, MockCloudBuildClient):
+        mock_client = MockCloudBuildClient.return_value
+        mock_trigger = MagicMock()
+        mock_trigger.name = self.trigger_name
+        mock_trigger.id = self.trigger_id
+        mock_client.list_build_triggers.return_value = [mock_trigger]
+        mock_client.list_builds.return_value = [] # No builds found
+
+        history = BuildHistory(self.project_id, self.region, self.max_retries, self.trigger_name)
+        build_dict = history._get_build_history()
+
+        self.assertEqual(build_dict, {})
+        mock_client.list_build_triggers.assert_called_once()
+        mock_client.list_builds.assert_called_once_with(request=cloudbuild.ListBuildsRequest(
+            project_id=self.project_id,
+            filter=f"trigger_id={self.trigger_id}",
+            parent=self.parent
+        ))
+
+    def test_get_build_history_with_builds(self, MockCloudBuildClient):
+        mock_client = MockCloudBuildClient.return_value
+        mock_trigger = MagicMock()
+        mock_trigger.name = self.trigger_name
+        mock_trigger.id = self.trigger_id
+        mock_client.list_build_triggers.return_value = [mock_trigger]
+
+        build1_zone1 = create_mock_build("b1", Status.FAILURE, {"_ZONE": "zone-a"})
+        build2_zone1 = create_mock_build("b2", Status.SUCCESS, {"_ZONE": "zone-a"})
+        build3_zone2 = create_mock_build("b3", Status.WORKING, {"_ZONE": "zone-b"})
+        build4_no_zone = create_mock_build("b4", Status.FAILURE, {}) # No _ZONE
+        build5_zone2_fail = create_mock_build("b5", Status.FAILURE, {"_ZONE": "zone-b"})
+
+        mock_client.list_builds.return_value = [
+            build5_zone2_fail, build4_no_zone, build3_zone2, build2_zone1, build1_zone1
+        ] # Order shouldn't matter for grouping, but does for status updates
+
+        history = BuildHistory(self.project_id, self.region, self.max_retries, self.trigger_name)
+        build_dict = history._get_build_history()
+
+        self.assertIn("zone-a", build_dict)
+        self.assertIn("zone-b", build_dict)
+        self.assertEqual(len(build_dict), 2) # build4_no_zone should be skipped
+
+        # Check zone-a summary (Failure then Success)
+        summary_a = build_dict["zone-a"]
+        self.assertEqual(summary_a.numberOfBuilds, 2)
+        self.assertEqual(summary_a.numberOfFailures, 1)
+        self.assertEqual(summary_a.latestStatus, Status.SUCCESS)
+        self.assertFalse(summary_a.retriable)
+
+        # Check zone-b summary (Working then Failure)
+        summary_b = build_dict["zone-b"]
+        self.assertEqual(summary_b.numberOfBuilds, 2)
+        self.assertEqual(summary_b.numberOfFailures, 1)
+        self.assertEqual(summary_b.latestStatus, Status.WORKING) # Working status persists
+        self.assertFalse(summary_b.retriable)
+
+        mock_client.list_builds.assert_called_once()
+
+    def test_get_build_history_multiple_matching_triggers(self, MockCloudBuildClient):
+        mock_client = MockCloudBuildClient.return_value
+        trigger1 = MagicMock(); trigger1.name = self.trigger_name; trigger1.id = "id1"
+        trigger2 = MagicMock(); trigger2.name = "other-trigger"; trigger2.id = "id-other"
+        trigger3 = MagicMock(); trigger3.name = self.trigger_name; trigger3.id = "id3"
+        mock_client.list_build_triggers.return_value = [trigger1, trigger2, trigger3]
+
+        mock_client.list_builds.return_value = []
+
+        history = BuildHistory(self.project_id, self.region, self.max_retries, self.trigger_name)
+        history._get_build_history()
+
+        expected_filter = "trigger_id=id1 OR trigger_id=id3"
+        mock_client.list_builds.assert_called_once_with(request=cloudbuild.ListBuildsRequest(
+            project_id=self.project_id,
+            filter=expected_filter,
+            parent=self.parent
+        ))
+
+    def test_should_retry_zone_build_zone_not_found(self, MockCloudBuildClient):
+        mock_client = MockCloudBuildClient.return_value
+        mock_trigger = MagicMock(); mock_trigger.name = self.trigger_name; mock_trigger.id = self.trigger_id
+        mock_client.list_build_triggers.return_value = [mock_trigger]
+        build1_zone1 = create_mock_build("b1", Status.FAILURE, {"_ZONE": "zone-a"})
+        mock_client.list_builds.return_value = [build1_zone1]
+
+        history = BuildHistory(self.project_id, self.region, self.max_retries, self.trigger_name)
+        # Zone 'zone-b' doesn't exist in history
+        self.assertFalse(history.should_retry_zone_build("zone-b"))
+        self.assertIn("zone-a", history.builds) # History should be populated
+
+    def test_should_retry_zone_build_is_retriable(self, MockCloudBuildClient):
+        mock_client = MockCloudBuildClient.return_value
+        mock_trigger = MagicMock(); mock_trigger.name = self.trigger_name; mock_trigger.id = self.trigger_id
+        mock_client.list_build_triggers.return_value = [mock_trigger]
+        build1_zone1 = create_mock_build("b1", Status.FAILURE, {"_ZONE": "zone-a"})
+        mock_client.list_builds.return_value = [build1_zone1]
+
+        history = BuildHistory(self.project_id, self.region, self.max_retries, self.trigger_name) # max_retries = 2
+        self.assertTrue(history.should_retry_zone_build("zone-a"))
+
+    def test_should_retry_zone_build_not_retriable_max_exceeded(self, MockCloudBuildClient):
+        mock_client = MockCloudBuildClient.return_value
+        mock_trigger = MagicMock(); mock_trigger.name = self.trigger_name; mock_trigger.id = self.trigger_id
+        mock_client.list_build_triggers.return_value = [mock_trigger]
+        build1 = create_mock_build("b1", Status.FAILURE, {"_ZONE": "zone-a"})
+        build2 = create_mock_build("b2", Status.TIMEOUT, {"_ZONE": "zone-a"})
+        build3 = create_mock_build("b3", Status.INTERNAL_ERROR, {"_ZONE": "zone-a"})
+        mock_client.list_builds.return_value = [build3, build2, build1] # 3 failures
+
+        history = BuildHistory(self.project_id, self.region, self.max_retries, self.trigger_name) # max_retries = 2
+        self.assertFalse(history.should_retry_zone_build("zone-a"))
+
+    def test_should_retry_zone_build_not_retriable_status_success(self, MockCloudBuildClient):
+        mock_client = MockCloudBuildClient.return_value
+        mock_trigger = MagicMock(); mock_trigger.name = self.trigger_name; mock_trigger.id = self.trigger_id
+        mock_client.list_build_triggers.return_value = [mock_trigger]
+        build1 = create_mock_build("b1", Status.FAILURE, {"_ZONE": "zone-a"})
+        build2 = create_mock_build("b2", Status.SUCCESS, {"_ZONE": "zone-a"})
+        mock_client.list_builds.return_value = [build2, build1]
+
+        history = BuildHistory(self.project_id, self.region, self.max_retries, self.trigger_name)
+        self.assertFalse(history.should_retry_zone_build("zone-a"))
+
+    def test_should_retry_zone_build_not_retriable_status_working(self, MockCloudBuildClient):
+        mock_client = MockCloudBuildClient.return_value
+        mock_trigger = MagicMock(); mock_trigger.name = self.trigger_name; mock_trigger.id = self.trigger_id
+        mock_client.list_build_triggers.return_value = [mock_trigger]
+        build1 = create_mock_build("b1", Status.FAILURE, {"_ZONE": "zone-a"})
+        build2 = create_mock_build("b2", Status.WORKING, {"_ZONE": "zone-a"})
+        mock_client.list_builds.return_value = [build2, build1]
+
+        history = BuildHistory(self.project_id, self.region, self.max_retries, self.trigger_name)
+        self.assertFalse(history.should_retry_zone_build("zone-a"))
+
+    def test_should_retry_zone_build_lazy_load(self, MockCloudBuildClient):
+        mock_client = MockCloudBuildClient.return_value
+        mock_trigger = MagicMock(); mock_trigger.name = self.trigger_name; mock_trigger.id = self.trigger_id
+        mock_client.list_build_triggers.return_value = [mock_trigger]
+        build1 = create_mock_build("b1", Status.FAILURE, {"_ZONE": "zone-a"})
+        mock_client.list_builds.return_value = [build1]
+
+        history = BuildHistory(self.project_id, self.region, self.max_retries, self.trigger_name)
+        self.assertIsNone(history.builds) # Initially None
+
+        # First call - fetches history
+        self.assertTrue(history.should_retry_zone_build("zone-a"))
+        self.assertIsNotNone(history.builds)
+        mock_client.list_builds.assert_called_once()
+
+        # Second call - uses cached history
+        mock_client.list_builds.reset_mock() # Reset mock call count
+        self.assertTrue(history.should_retry_zone_build("zone-a"))
+        mock_client.list_builds.assert_not_called() # Should not call again
+
+    def test_should_retry_zone_build_missing_zone_name(self, MockCloudBuildClient):
+        history = BuildHistory(self.project_id, self.region, self.max_retries, self.trigger_name)
+        with self.assertRaisesRegex(Exception, 'missing zone_name'):
+            history.should_retry_zone_build(None)
+        with self.assertRaisesRegex(Exception, 'missing zone_name'):
+            history.should_retry_zone_build("")


### PR DESCRIPTION
By default, `cluster-creation-max-retries` is set to 0 and will skip any automated retry logic.

When enabled, there is coordination between zone-watcher and the create-cluster cloud build trigger:

- Zone watcher
    - Queries cloud build to capture builds for a specific zone
    - In the scenario where a build has failed, zone watcher owns the decision to retry.
    - If the maximum number of retries have been exceeded, then zone watcher will skip that zone.
 - create-cluster cloud build trigger
     - If a build fails, it will query cloud build for the number of total failures for a specific zone
     - If the number of builds is less than the max number of allowable retries, then the script will exit without changing zone state
     - If the number of builds is more than the max number of allowable retries, then the script will update zone state to `FACTORY_TURNUP_CHECKS_FAILED` and exit. 