### PR TITLE
fix: Fix logic when using incorrect trigger id

### DIFF
--- a/watchers/src/build_history.py
+++ b/watchers/src/build_history.py
@@ -117,7 +117,7 @@ class BuildHistory:
             if not zone:
                 # Builds are expected to have the _ZONE substitution. This is the value that is
                 # matched on to calculate whether a build should be retried or not. 
-                logging.warning(f"build found within _ZONE substitution, skipping... Build ID: {response.id}")
+                logging.warning(f"build found without _ZONE substitution, skipping... Build ID: {response.id}")
                 continue
 
             if zone in build_summary_dict:

--- a/watchers/src/build_history.py
+++ b/watchers/src/build_history.py
@@ -80,15 +80,15 @@ class BuildHistory:
 
         triggers = self.client.list_build_triggers(trigger_request)
 
-        if len(triggers) == 0:
-            raise Exception(f"No triggers found named {self.trigger_name}")
-
         for trigger in triggers:
             if (trigger.name == self.trigger_name):
                 if trigger_name_filter == "":
                     trigger_name_filter += f"trigger_id={trigger.id}"
                 else:
                     trigger_name_filter += f" OR trigger_id={trigger.id}"
+
+        if trigger_name_filter == "":
+            raise Exception(f"No triggers found named {self.trigger_name}")
 
         request = cloudbuild.ListBuildsRequest(
             project_id=self.project_id,

--- a/watchers/tests/test_build_history.py
+++ b/watchers/tests/test_build_history.py
@@ -197,17 +197,8 @@ class TestBuildHistory(unittest.TestCase):
         mock_client.list_build_triggers.return_value = [mock_trigger]
 
         history = BuildHistory(self.project_id, self.region, self.max_retries, self.trigger_name)
-        build_dict = history._get_build_history()
 
-        self.assertEqual(build_dict, {})
-        mock_client.list_build_triggers.assert_called_once()
-        # Should call list_builds with an empty filter if no matching triggers found
-        mock_client.list_builds.assert_called_once_with(request=cloudbuild.ListBuildsRequest(
-            project_id=self.project_id,
-            filter="", # Empty filter
-            parent=self.parent
-        ))
-
+        self.assertRaises(Exception, history._get_build_history)
 
     def test_get_build_history_matching_trigger_no_builds(self, MockCloudBuildClient):
         mock_client = MockCloudBuildClient.return_value


### PR DESCRIPTION
The current logic throws an error of `TypeError: object of type 'ListBuildTriggersPager' has no len()`. This change fixes it so that if no triggers are found with a given name, it throws an exception (because it's likely a typo or incorrect configuration). 