### PR TITLE
fix: Check for CUSTOMER_FACTORY_TURNUP_CHECKS_STARTED for retry behavior

### DIFF
--- a/watchers/src/main.py
+++ b/watchers/src/main.py
@@ -596,7 +596,10 @@ def verify_zone_state(store_id: str, recreate_on_delete: bool) -> bool:
         if cluster can be created or not
     """
     state = get_zone_state(store_id)
-    if state == Zone.State.READY_FOR_CUSTOMER_FACTORY_TURNUP_CHECKS:
+
+    # READY_FOR_CUSTOMER_FACTORY_TURNUP_CHECKS, provisioning has not yet been attempted
+    # CUSTOMER_FACTORY_TURNUP_CHECKS_STARTED, provisioning has been attempted and is either in progress or failed
+    if state == Zone.State.READY_FOR_CUSTOMER_FACTORY_TURNUP_CHECKS or state == Zone.State.CUSTOMER_FACTORY_TURNUP_CHECKS_STARTED :
         logger.info(f'Store is ready for provisioning: "{store_id}"')
         return True
 

--- a/watchers/src/requirements.txt
+++ b/watchers/src/requirements.txt
@@ -4,10 +4,10 @@ google-cloud-build==3.24.2
 google-cloud-compute==1.19.2
 google-cloud-edgecontainer==0.5.11
 google-cloud-edgenetwork==0.1.10
-google-cloud-gdchardwaremanagement==0.1.8
+google-cloud-gdchardwaremanagement==0.1.12
 google-cloud-gke-hub==1.16.0
 google-cloud-monitoring==2.22.2
 google-cloud-secret-manager==2.20.2
 google-cloud-storage==2.18.2
 python-dateutil==2.9.0.post0
-protobuf==5.29.3
+protobuf==5.29.5

--- a/watchers/tests/test_main.py
+++ b/watchers/tests/test_main.py
@@ -30,6 +30,10 @@ class TestMain(unittest.TestCase):
 
         self.assertTrue(result)
 
+        mock_zone.state = Zone.State.CUSTOMER_FACTORY_TURNUP_CHECKS_STARTED
+        result = main.verify_zone_state("mock_store_id", False)
+        self.assertTrue(result)
+
     @mock.patch('google.cloud.gdchardwaremanagement_v1alpha.GDCHardwareManagementClient')
     def test_zone_recreation_flag(self, mock_client):
         mock_zone = mock.MagicMock()


### PR DESCRIPTION
Zone State changes to: CUSTOMER_FACTORY_TURNUP_CHECKS_STARTED after https://github.com/GDC-ConsumerEdge/automated-cluster-provisioner/blob/main/bootstrap/create-cluster.yaml#L60.

Since retries under the max limit do not change ZoneState (https://github.com/GDC-ConsumerEdge/automated-cluster-provisioner/blob/main/bootstrap/create-cluster.yaml#L49), the Zone Watcher needs to treat CUSTOMER_FACTORY_TURNUP_CHECKS_STARTED as ready for provisioning. 