### PR TITLE
feat: Support enable robin cns for cluster creation and update

### DIFF
--- a/module/create-cluster.yaml
+++ b/module/create-cluster.yaml
@@ -293,10 +293,14 @@ steps:
       # This is used to output the opid before the operation has completed
       exec 5>&1
 
+      GCLOUD_CMD="gcloud"
+
       ROBIN_CNS_ARG=""
       if [[ "${ENABLE_ROBIN_CNS}" == "TRUE" ]] && gdc_version_evaluate "${CLUSTER_VERSION}" "1.12.0"; then
-        log_build_step "Enabling Robin CNS"
+        log_build_step "Creating cluster with Robin CNS enabled"
         ROBIN_CNS_ARG="--enable-robin-cns"
+        # Update command to use alpha until this flag is GA'ed
+        GCLOUD_CMD="gcloud alpha"
       fi
 
       IDENTITY_SERVICE_ARG=""
@@ -308,7 +312,7 @@ steps:
       fi
 
       out=$(
-        gcloud edge-cloud container clusters create $CLUSTER_NAME \
+        ${GCLOUD_CMD} edge-cloud container clusters create $CLUSTER_NAME \
           --control-plane-node-location=$NODE_LOCATION \
           --control-plane-node-count=$NODE_COUNT \
           --cluster-ipv4-cidr=$CLUSTER_IPV4_CIDR \

--- a/module/create-cluster.yaml
+++ b/module/create-cluster.yaml
@@ -293,6 +293,12 @@ steps:
       # This is used to output the opid before the operation has completed
       exec 5>&1
 
+      ROBIN_CNS_ARG=""
+      if [[ "${ENABLE_ROBIN_CNS}" == "TRUE" ]] && gdc_version_evaluate "${CLUSTER_VERSION}" "1.12.0"; then
+        log_build_step "Enabling Robin CNS"
+        ROBIN_CNS_ARG="--enable-robin-cns"
+      fi
+
       IDENTITY_SERVICE_ARG=""
       if [[ "${SKIP_IDENTITY_SERVICE}" == "FALSE" ]] && gdc_version_evaluate "${CLUSTER_VERSION}" "1.10.0"; then
         log_build_step "Creating cluster with Group RBAC"
@@ -314,6 +320,7 @@ steps:
           --release-channel=NONE \
           --version $CLUSTER_VERSION \
           --offline-reboot-ttl=7d \
+          ${ROBIN_CNS_ARG} \
           ${IDENTITY_SERVICE_ARG} 2>&1 | tee /dev/fd/5
         )
 
@@ -504,6 +511,7 @@ steps:
   - 'MAX_RETRIES=$_MAX_RETRIES'
   - 'TRIGGER_NAME=$TRIGGER_NAME'
   - 'OPT_IN_BUILD_MESSAGES=$_OPT_IN_BUILD_MESSAGES'
+  - 'ENABLE_ROBIN_CNS=$_ENABLE_ROBIN_CNS'
 
 options:
   logging: CLOUD_LOGGING_ONLY

--- a/module/main.tf
+++ b/module/main.tf
@@ -33,6 +33,7 @@ locals {
     var.skip_identity_service == true ? { _SKIP_IDENTITY_SERVICE = "TRUE" } : {_SKIP_IDENTITY_SERVICE = "FALSE"},
     var.bart_create_bucket == true ? { _BART_CREATE_BUCKET = "TRUE" } : { _BART_CREATE_BUCKET = "FALSE" },
     var.opt_in_build_messages == true ? { _OPT_IN_BUILD_MESSAGES = "TRUE" } : { _OPT_IN_BUILD_MESSAGES = "FALSE" },
+    var.enable_robin_cns == true ? { _ENABLE_ROBIN_CNS = "TRUE" } : { _ENABLE_ROBIN_CNS = "FALSE" },
   )
   project_id_fleet   = coalesce(var.project_id_fleet, var.project_id)
   project_id_secrets = coalesce(var.project_id_secrets, var.project_id)

--- a/module/modify-cluster.yaml
+++ b/module/modify-cluster.yaml
@@ -52,6 +52,45 @@ steps:
       echo "$output"
     }
 
+    # Use this function to determine if the required version is met. 
+    # Return true if met. Return false if not met. 
+    # This can be used when version checking is important.
+    function gdc_version_evaluate() {
+      current_version="$1"
+      required_version="$2"
+
+      regex='^([0-9]+(\.[0-9]+)*)'
+
+      if [[ "$current_version" =~ $regex ]]; then
+          current_numeric="${BASH_REMATCH[1]}"
+      else
+          echo "Error Could not extract numeric part from current version: '$current_version'. Should be in the format X.Y.X, like 1.8.0." >&2
+          return 1
+      fi
+
+      if [[ "$required_version" =~ $regex ]]; then
+          required_numeric="${BASH_REMATCH[1]}"
+      else
+          echo "Error Could not extract numeric part from target version: '$required_version'. Should be in the format X.Y.X, like 1.8.0." >&2
+          return 1 
+      fi
+
+      if [[ "$current_numeric" == "$required_numeric" ]]; then
+          return 0 # Versions are equal
+      fi
+
+      first_sorted_version=$(printf "%s\n%s\n" "$current_numeric" "$required_numeric" | sort -V | head -n1)
+
+
+      if [[ "$first_sorted_version" == "$required_numeric" ]]; then 
+          # current_version > required_version
+          return  0
+      else
+          # current_version < required_version
+          return 1
+      fi
+    }
+
     [[ -z "${STORE_ID}" ]] && die "STORE_ID not set"
 
     NODE_LOCATION=${ZONE}
@@ -84,6 +123,7 @@ steps:
     export MAINTENANCE_WINDOW_RECURRENCE=$(parse_csv_optional "$CLUSTER_INTENT" "maintenance_window_recurrence")
     export SUBNET_VLANS=$(parse_csv_optional "$CLUSTER_INTENT" "subnet_vlans")
     export LABELS=$(parse_csv_optional "$CLUSTER_INTENT" "labels")
+    export CLUSTER_VERSION=$(parse_csv_required "$CLUSTER_INTENT" "cluster_version")
 
     export MAINTENANCE_EXCLUSION_NAMES=$(echo "$CLUSTER_INTENT" | head -n1 | tr , '\n' | tr -d '"' | sort -n | grep 'maintenance_exclusion_name.*')
     export MAINTENANCE_EXCLUSION_STARTS=$(echo "$CLUSTER_INTENT" | head -n1 | tr , '\n' |  tr -d '"' | sort -n | grep 'maintenance_exclusion_start.*')
@@ -202,6 +242,15 @@ steps:
       fi
     done
 
+    ROBIN_CNS_ARG=""
+    if [[ "${ENABLE_ROBIN_CNS}" == "TRUE" ]] && gdc_version_evaluate "${CLUSTER_VERSION}" "1.12.0"; then
+      echo "Enabling Robin CNS"
+      gcloud edge-cloud container clusters update $CLUSTER_NAME \
+        --project=$FLEET_PROJECT_ID \
+        --location=$LOCATION \
+        --enable-robin-cns
+    fi
+
     echo "Cluster Modify Succeeded: $CLUSTER_NAME"
 
   env:
@@ -217,6 +266,7 @@ steps:
   - 'GIT_SECRETS_PROJECT_ID=$_GIT_SECRETS_PROJECT_ID'
   - 'STORE_ID=$_STORE_ID'
   - 'ZONE=$_ZONE'
+  - 'ENABLE_ROBIN_CNS=$_ENABLE_ROBIN_CNS'
 
 timeout: 600s
 options:

--- a/module/modify-cluster.yaml
+++ b/module/modify-cluster.yaml
@@ -245,7 +245,7 @@ steps:
     ROBIN_CNS_ARG=""
     if [[ "${ENABLE_ROBIN_CNS}" == "TRUE" ]] && gdc_version_evaluate "${CLUSTER_VERSION}" "1.12.0"; then
       echo "Enabling Robin CNS"
-      gcloud edge-cloud container clusters update $CLUSTER_NAME \
+      gcloud alpha edge-cloud container clusters update $CLUSTER_NAME \
         --project=$FLEET_PROJECT_ID \
         --location=$LOCATION \
         --enable-robin-cns

--- a/module/variables.tf
+++ b/module/variables.tf
@@ -199,3 +199,9 @@ variable "vpc_connector_egress_settings" {
   type        = string
   default     = null
 }
+
+variable "enable_robin_cns" {
+  description = "Enable Robin Cloud Native Storage (CNS)"
+  type        = bool
+  default     = false
+}


### PR DESCRIPTION
Add support for enabling robin cns feature for cluster creation and update, this is done by adding `--enable-robin-cns` flag if `enable_robin_cns` variable is set to true.