### PR TITLE
Implement granular retry logic for cluster builds

### DIFF
--- a/module/create-cluster.yaml
+++ b/module/create-cluster.yaml
@@ -43,10 +43,10 @@ steps:
         # Instead of querying build history with gcloud (which is slow and was counting builds from previous lifecycles),
         # we directly use the TRY_COUNT passed from Zone Watcher to check if we exceeded MAX_RETRIES.
         if [[ "$TRY_COUNT" -gt "$MAX_RETRIES" ]]; then
-          echo ">>> [ERROR] Current try count $TRY_COUNT has exhausteds max retries $MAX_RETRIES. Marking zone as failed"
+          echo ">>> [ERROR] Current try count $TRY_COUNT has exhausted max retries $MAX_RETRIES. Marking zone as failed"
           zone_signal $ZONE_ID FACTORY_TURNUP_CHECKS_FAILED "$step" "$details"
         else
-          echo ">>> [ERROR] Current try count $TRY_COUNT is <= max retries $MAX_RETRIES. Skipping for next retry"
+          echo ">>> [ERROR] Current try count $TRY_COUNT is <= max retries $MAX_RETRIES. Skipping failure signal to allow next retry."
         fi
       fi
 

--- a/module/create-cluster.yaml
+++ b/module/create-cluster.yaml
@@ -40,14 +40,13 @@ steps:
         echo ">>> [ERROR] Marking zone as failed"
         zone_signal $ZONE_ID FACTORY_TURNUP_CHECKS_FAILED "$step" "$details"
       else
-        # Will include the current build as well
-        BUILD_COUNT=$(gcloud builds list --filter "tags='$STORE_ID' AND substitutions.TRIGGER_NAME='$TRIGGER_NAME'" --region us-central1 --format="csv[no-heading](name)" | wc -l)
-
-        if [[ "$BUILD_COUNT" -gt "$MAX_RETRIES" ]]; then
-          echo ">>> [ERROR] Current build count $BUILD_COUNT exceeds max retries $MAX_RETRIES. Marking zone as failed"
+        # Instead of querying build history with gcloud (which is slow and was counting builds from previous lifecycles),
+        # we directly use the TRY_COUNT passed from Zone Watcher to check if we exceeded MAX_RETRIES.
+        if [[ "$TRY_COUNT" -gt "$MAX_RETRIES" ]]; then
+          echo ">>> [ERROR] Current try count $TRY_COUNT has exhausteds max retries $MAX_RETRIES. Marking zone as failed"
           zone_signal $ZONE_ID FACTORY_TURNUP_CHECKS_FAILED "$step" "$details"
         else
-          echo ">>> [ERROR] Current build count $BUILD_COUNT is <= max retries $MAX_RETRIES. Skipping for next retry"
+          echo ">>> [ERROR] Current try count $TRY_COUNT is <= max retries $MAX_RETRIES. Skipping for next retry"
         fi
       fi
 
@@ -571,6 +570,8 @@ steps:
   - 'MAX_RETRIES=$_MAX_RETRIES'
   - 'TRIGGER_NAME=$TRIGGER_NAME'
   - 'OPT_IN_BUILD_MESSAGES=$_OPT_IN_BUILD_MESSAGES'
+  - 'TRY_COUNT=$_TRY_COUNT'
+  - 'INTENT_HASH=$_INTENT_HASH'
 
 options:
   logging: CLOUD_LOGGING_ONLY

--- a/module/watchers/src/build_history.py
+++ b/module/watchers/src/build_history.py
@@ -9,8 +9,6 @@ logger.setLevel(os.environ.get("LOG_LEVEL", "INFO").upper())
 
 class BuildSummary:
     latestStatus: Build.Status = None
-    numberOfBuilds: int = 0
-    numberOfFailures: int = 0
     retriable: bool = False
     latest_try_count: int = 0
 
@@ -23,25 +21,8 @@ class BuildSummary:
         #    in any of the previous recorded attempts in this history window.
         # 4. Usage Context: Note that this `retriable` result is only checked in main.py when cluster_exists is True
         #    or when there are not enough free machines.
-        self.numberOfBuilds += 1
 
-        if build.status not in (
-            cloudbuild.Build.Status.QUEUED,
-            cloudbuild.Build.Status.PENDING,
-            cloudbuild.Build.Status.WORKING,
-            cloudbuild.Build.Status.SUCCESS):
-            self.numberOfFailures += 1
-
-        # This means that there is a build in progress and we should not retry or change the status
-        if self.latestStatus in (cloudbuild.Build.Status.QUEUED, cloudbuild.Build.Status.PENDING, cloudbuild.Build.Status.WORKING):
-            self.retriable = False
-            return
-
-        # This means that there was a successful build and we should not retry
-        if self.latestStatus == cloudbuild.Build.Status.SUCCESS:
-            self.retriable = False
-            return
-        
+        # latestStatus will only be updated with non-failure statuses.
         if build.status in (cloudbuild.Build.Status.QUEUED, cloudbuild.Build.Status.PENDING, cloudbuild.Build.Status.WORKING):
             self.latestStatus = build.status
             self.retriable = False
@@ -52,9 +33,6 @@ class BuildSummary:
             # Any status in this category can be treated as a failure
             self.retriable = True
 
-
-
-
 class BuildHistory:
     def __init__(self, project_id: str, region: str, max_retries: int, trigger_name: str):
         self.project_id = project_id
@@ -62,9 +40,9 @@ class BuildHistory:
         self.max_retries = max_retries
         self.trigger_name = trigger_name
         self.client = cloudbuild.CloudBuildClient()
-        self.builds: Dict[str, BuildSummary] = self._get_build_history()
+        self.builds: Dict[tuple[str, str], BuildSummary] = self._get_build_history()
 
-    def _get_build_history(self) ->Dict[str, BuildSummary]:
+    def _get_build_history(self) ->Dict[tuple[str, str], BuildSummary]:
         """
         Queries for Cloud Build history matching a specific trigger name.
 
@@ -72,9 +50,9 @@ class BuildHistory:
             trigger_name: The name of the Cloud Build trigger.
 
         Returns:
-            A dictionary with the zone name as the key and the build summary
-            which contains relevant information to determine if a retry should
-            be triggered.
+            A dictionary with the zone name and intent hash tuple as the key 
+            and the build summary which contains relevant information to 
+            determine if a retry should be triggered.
         """
         trigger_request = cloudbuild.ListBuildTriggersRequest(
             project_id = self.project_id,
@@ -105,7 +83,7 @@ class BuildHistory:
 
         # Only page through last 1,000 builds
         build_entries = 0
-        build_summary_dict: Dict[str, BuildSummary] = dict()
+        build_summary_dict: Dict[tuple[str, str], BuildSummary] = dict()
 
         for response in page_result:
             build_entries += 1
@@ -125,13 +103,18 @@ class BuildHistory:
             if not zone:
                 # Builds are expected to have the _ZONE substitution. This is the value that is
                 # matched on to calculate whether a build should be retried or not. 
-                logging.warning(f"build found without _ZONE substitution, skipping... Build ID: {response.id}")
+                logger.warning(f"build found without _ZONE substitution, skipping... Build ID: {response.id}")
                 continue
 
             key = (zone, intent_hash)
 
             if key in build_summary_dict:
                 summary = build_summary_dict[key]
+                # Since we process from newest to oldest, once we have found a non-failure
+                # status (latestStatus is set), older builds will not change the outcome.
+                # We can safely skip calling add_build for them.
+                if summary.latestStatus is not None:
+                    continue
                 summary.add_build(response)
             else:
                 summary = BuildSummary()

--- a/module/watchers/src/build_history.py
+++ b/module/watchers/src/build_history.py
@@ -8,9 +8,10 @@ logger = logging.getLogger(__name__)
 logger.setLevel(os.environ.get("LOG_LEVEL", "INFO").upper())
 
 class BuildSummary:
-    latestStatus: Build.Status = None
+    latest_non_failure_status: Build.Status = None
     retriable: bool = False
     latest_try_count: int = 0
+    latest_attempt_failed: bool = False
 
     def add_build(self, build: cloudbuild.Build):
         # NOTE on processing order and retry logic:
@@ -22,12 +23,12 @@ class BuildSummary:
         # 4. Usage Context: Note that this `retriable` result is only checked in main.py when cluster_exists is True
         #    or when there are not enough free machines.
 
-        # latestStatus will only be updated with non-failure statuses.
+        # latest_non_failure_status will only be updated with non-failure statuses.
         if build.status in (cloudbuild.Build.Status.QUEUED, cloudbuild.Build.Status.PENDING, cloudbuild.Build.Status.WORKING):
-            self.latestStatus = build.status
+            self.latest_non_failure_status = build.status
             self.retriable = False
         elif build.status == cloudbuild.Build.Status.SUCCESS:
-            self.latestStatus = build.status
+            self.latest_non_failure_status = build.status
             self.retriable = False
         else:
             # Any status in this category can be treated as a failure
@@ -111,17 +112,26 @@ class BuildHistory:
             if key in build_summary_dict:
                 summary = build_summary_dict[key]
                 # Since we process from newest to oldest, once we have found a non-failure
-                # status (latestStatus is set), older builds will not change the outcome.
+                # status (latest_non_failure_status is set), older builds will not change the outcome.
                 # We can safely skip calling add_build for them.
-                if summary.latestStatus is not None:
+                if summary.latest_non_failure_status is not None:
                     continue
                 summary.add_build(response)
             else:
                 summary = BuildSummary()
+                
+                # Check if the absolute newest build failed
+                summary.latest_attempt_failed = response.status not in (
+                    cloudbuild.Build.Status.SUCCESS,
+                    cloudbuild.Build.Status.WORKING,
+                    cloudbuild.Build.Status.QUEUED,
+                    cloudbuild.Build.Status.PENDING
+                )
+                
                 try_count_str = response.substitutions.get("_TRY_COUNT", "0")
                 summary.latest_try_count = int(try_count_str)
                 summary.add_build(response)
-                logger.info(f"Found latest build for zone {zone} with hash {intent_hash}. Latest try_count={summary.latest_try_count}")
+                logger.info(f"Found latest build for zone {zone} with hash {intent_hash}. Latest try_count={summary.latest_try_count}, latest_attempt_failed={summary.latest_attempt_failed}")
                 build_summary_dict[key] = summary
 
         return build_summary_dict

--- a/module/watchers/src/build_history.py
+++ b/module/watchers/src/build_history.py
@@ -12,8 +12,17 @@ class BuildSummary:
     numberOfBuilds: int = 0
     numberOfFailures: int = 0
     retriable: bool = False
+    latest_try_count: int = 0
 
     def add_build(self, build: cloudbuild.Build):
+        # NOTE on processing order and retry logic:
+        # 1. Processing Order: Since ListBuilds returns newest first, this loop processes builds from newest to oldest.
+        # 2. Logic Intent: This logic effectively finds the most recent non-failure build (moving backwards in time)
+        #    and uses its status to determine if we should retry.
+        # 3. Retry Condition: It will only allow a retry if the newest build failed AND the cluster has not succeeded
+        #    in any of the previous recorded attempts in this history window.
+        # 4. Usage Context: Note that this `retriable` result is only checked in main.py when cluster_exists is True
+        #    or when there are not enough free machines.
         self.numberOfBuilds += 1
 
         if build.status not in (
@@ -43,11 +52,7 @@ class BuildSummary:
             # Any status in this category can be treated as a failure
             self.retriable = True
 
-    def is_retriable(self, max_retries: int):
-        if self.numberOfFailures > max_retries:
-            return False
-        
-        return self.retriable
+
 
 
 class BuildHistory:
@@ -109,10 +114,13 @@ class BuildHistory:
                 break
 
             zone = ""
+            intent_hash = ""
 
             for key in response.substitutions:
                 if key == "_ZONE":
                     zone = response.substitutions[key]
+                elif key == "_INTENT_HASH":
+                    intent_hash = response.substitutions[key]
 
             if not zone:
                 # Builds are expected to have the _ZONE substitution. This is the value that is
@@ -120,32 +128,48 @@ class BuildHistory:
                 logging.warning(f"build found without _ZONE substitution, skipping... Build ID: {response.id}")
                 continue
 
-            if zone in build_summary_dict:
-                summary = build_summary_dict[zone]
+            key = (zone, intent_hash)
+
+            if key in build_summary_dict:
+                summary = build_summary_dict[key]
                 summary.add_build(response)
             else:
                 summary = BuildSummary()
+                try_count_str = response.substitutions.get("_TRY_COUNT", "0")
+                summary.latest_try_count = int(try_count_str)
                 summary.add_build(response)
-                build_summary_dict[zone] = summary
+                logger.info(f"Found latest build for zone {zone} with hash {intent_hash}. Latest try_count={summary.latest_try_count}")
+                build_summary_dict[key] = summary
 
         return build_summary_dict
 
-    def should_retry_zone_build(self, zone_name: str):
+    def should_retry_zone_build(self, zone_name: str, intent_hash: str):
         """
         Determines if a build should be retried or not. `False` is returned in the event 
         of no build history for a zone. 
 
         Args:
             zone_name: The name of the zone
+            intent_hash: The hash of the cluster intent
         """
         if not zone_name:
             raise Exception('missing zone_name')
         
-        if zone_name not in self.builds:
+        key = (zone_name, intent_hash)
+        if key not in self.builds:
             return False
         else:
-            build = self.builds[zone_name]
-            return build.is_retriable(self.max_retries)
+            build = self.builds[key]
+            return build.retriable
+
+    def get_latest_try_count(self, zone_name: str, intent_hash: str) -> int:
+        """
+        Returns the latest try count for a zone and intent hash.
+        """
+        key = (zone_name, intent_hash)
+        if key not in self.builds:
+            return 0
+        return self.builds[key].latest_try_count
 
         
         

--- a/module/watchers/src/build_history.py
+++ b/module/watchers/src/build_history.py
@@ -13,7 +13,7 @@ class BuildSummary:
     latest_try_count: int = 0
     latest_attempt_failed: bool = False
 
-    def add_build(self, build: cloudbuild.Build):
+    def flag_first_non_failure_build(self, build: cloudbuild.Build):
         # NOTE on processing order and retry logic:
         # 1. Processing Order: Since ListBuilds returns newest first, this loop processes builds from newest to oldest.
         # 2. Logic Intent: This logic effectively finds the most recent non-failure build (moving backwards in time)
@@ -24,10 +24,7 @@ class BuildSummary:
         #    or when there are not enough free machines.
 
         # latest_non_failure_status will only be updated with non-failure statuses.
-        if build.status in (cloudbuild.Build.Status.QUEUED, cloudbuild.Build.Status.PENDING, cloudbuild.Build.Status.WORKING):
-            self.latest_non_failure_status = build.status
-            self.retriable = False
-        elif build.status == cloudbuild.Build.Status.SUCCESS:
+        if build.status in (cloudbuild.Build.Status.QUEUED, cloudbuild.Build.Status.PENDING, cloudbuild.Build.Status.WORKING, cloudbuild.Build.Status.SUCCESS):
             self.latest_non_failure_status = build.status
             self.retriable = False
         else:
@@ -113,10 +110,10 @@ class BuildHistory:
                 summary = build_summary_dict[key]
                 # Since we process from newest to oldest, once we have found a non-failure
                 # status (latest_non_failure_status is set), older builds will not change the outcome.
-                # We can safely skip calling add_build for them.
+                # We can safely skip calling flag_first_non_failure_build for them.
                 if summary.latest_non_failure_status is not None:
                     continue
-                summary.add_build(response)
+                summary.flag_first_non_failure_build(response)
             else:
                 summary = BuildSummary()
                 
@@ -130,7 +127,7 @@ class BuildHistory:
                 
                 try_count_str = response.substitutions.get("_TRY_COUNT", "0")
                 summary.latest_try_count = int(try_count_str)
-                summary.add_build(response)
+                summary.flag_first_non_failure_build(response)
                 logger.info(f"Found latest build for zone {zone} with hash {intent_hash}. Latest try_count={summary.latest_try_count}, latest_attempt_failed={summary.latest_attempt_failed}")
                 build_summary_dict[key] = summary
 

--- a/module/watchers/src/main.py
+++ b/module/watchers/src/main.py
@@ -126,8 +126,6 @@ def _zone_watcher_worker(
             else:
                 logger.info(f'ZONE {zone}: {m.name} is a free node')
                 count_of_free_machines = count_of_free_machines+1
-
-        zone_state = zones[zone_store_id].state
  
         if cluster_exists and not builds.should_retry_zone_build(zone, store_info.intent_hash):
             logger.info(f'Cluster already exists for {zone}. Skipping..')
@@ -139,7 +137,8 @@ def _zone_watcher_worker(
             logger.info(f'ZONE {zone}: Not enough free  nodes to create cluster. Need {str(store_info.node_count)} but have {str(count_of_free_machines)} free nodes')
             if not builds.should_retry_zone_build(zone, store_info.intent_hash):
                 continue
- 
+
+        zone_state = zones[zone_store_id].state
         if zone_name_retrieved_from_api and not verify_zone_state(zone_state, zone_store_id, store_info.recreate_on_delete):
             logger.info(f'Zone: {zone}, Store: {store_id} is not in expected state! skipping..')
             continue
@@ -148,13 +147,12 @@ def _zone_watcher_worker(
         # If state is READY, it's a fresh start (or manual reset), so start at 1.
         # If state is STARTED, it's a continuation of an attempt, so increment from history.
         try_count = 1
-        if zone_state == Zone.State.READY_FOR_CUSTOMER_FACTORY_TURNUP_CHECKS:
-            logger.info(f'Zone {zone} is in READY state. Starting with try_count=1.')
-            try_count = 1
+        if zone_state in (Zone.State.READY_FOR_CUSTOMER_FACTORY_TURNUP_CHECKS, Zone.State.ACTIVE):
+            logger.info(f'Zone {zone} is in {zone_state.name} state. Starting with try_count=1.')
         elif zone_state == Zone.State.CUSTOMER_FACTORY_TURNUP_CHECKS_STARTED:
             latest_try = builds.get_latest_try_count(zone, store_info.intent_hash)
             try_count = latest_try + 1
-            logger.info(f'Zone {zone} is in STARTED state. Latest try_count from history was {latest_try}. Setting next try_count={try_count}.')
+            logger.info(f'Zone {zone} is in {zone_state.name} state. Latest try_count from history was {latest_try}. Setting next try_count={try_count}.')
             
         # Pre-emptively skip if we have exceeded the allowed attempts (max_retries + 1).
         # This avoids triggering a build that we know will fail in the Bash script.

--- a/module/watchers/src/main.py
+++ b/module/watchers/src/main.py
@@ -20,6 +20,8 @@ import flask
 from collections import defaultdict
 import csv
 import logging
+import json
+import hashlib
 from google.api_core.operation import Operation
 from pydantic import ValidationError
 import requests
@@ -125,27 +127,49 @@ def _zone_watcher_worker(
                 logger.info(f'ZONE {zone}: {m.name} is a free node')
                 count_of_free_machines = count_of_free_machines+1
 
-        if cluster_exists and not builds.should_retry_zone_build(zone):
+        zone_state = zones[zone_store_id].state
+ 
+        if cluster_exists and not builds.should_retry_zone_build(zone, store_info.intent_hash):
             logger.info(f'Cluster already exists for {zone}. Skipping..')
             continue
-
+ 
         if count_of_free_machines >= int(store_info.node_count):
             logger.info(f'ZONE {zone}: There are enough free  nodes to create cluster')
         else:
             logger.info(f'ZONE {zone}: Not enough free  nodes to create cluster. Need {str(store_info.node_count)} but have {str(count_of_free_machines)} free nodes')
-            if not builds.should_retry_zone_build(zone):
+            if not builds.should_retry_zone_build(zone, store_info.intent_hash):
                 continue
-
-        if zone_name_retrieved_from_api and not verify_zone_state(zones[zone_store_id].state ,zone_store_id, store_info.recreate_on_delete):
+ 
+        if zone_name_retrieved_from_api and not verify_zone_state(zone_state, zone_store_id, store_info.recreate_on_delete):
             logger.info(f'Zone: {zone}, Store: {store_id} is not in expected state! skipping..')
             continue
-
+ 
+        # Determine the try count for the next build.
+        # If state is READY, it's a fresh start (or manual reset), so start at 1.
+        # If state is STARTED, it's a continuation of an attempt, so increment from history.
+        try_count = 1
+        if zone_state == Zone.State.READY_FOR_CUSTOMER_FACTORY_TURNUP_CHECKS:
+            logger.info(f'Zone {zone} is in READY state. Starting with try_count=1.')
+            try_count = 1
+        elif zone_state == Zone.State.CUSTOMER_FACTORY_TURNUP_CHECKS_STARTED:
+            latest_try = builds.get_latest_try_count(zone, store_info.intent_hash)
+            try_count = latest_try + 1
+            logger.info(f'Zone {zone} is in STARTED state. Latest try_count from history was {latest_try}. Setting next try_count={try_count}.')
+            
+        # Pre-emptively skip if we have exceeded the allowed attempts (max_retries + 1).
+        # This avoids triggering a build that we know will fail in the Bash script.
+        if try_count > params.max_retries + 1:
+            logger.info(f'Max retries reached for zone {zone} (try_count={try_count}, max_retries={params.max_retries}). Skipping..')
+            continue
+ 
         # trigger cloudbuild to initiate the cluster building
         repo_source = cloudbuild.RepoSource()
         repo_source.branch_name = store_info.sync_branch
         repo_source.substitutions = {
             "_STORE_ID": store_id,
-            "_ZONE": zone
+            "_ZONE": zone,
+            "_INTENT_HASH": store_info.intent_hash,
+            "_TRY_COUNT": str(try_count)
         }
         req = cloudbuild.RunBuildTriggerRequest(
             name=params.cloud_build_trigger,
@@ -529,8 +553,13 @@ def read_intent_data(params, named_key) -> Dict[Tuple, Dict[str, SourceOfTruthMo
         if proj_loc_key not in config_zone_info.keys():
             config_zone_info[proj_loc_key] = {}
 
+        # Calculate hash of the row
+        row_str = json.dumps(row, sort_keys=True)
+        intent_hash = hashlib.sha256(row_str.encode()).hexdigest()
+
         try:
             edge_zone = SourceOfTruthModel.model_validate(row)
+            edge_zone.intent_hash = intent_hash
         except ValidationError as e:
             logger.error(f"Invalid row detected in source of truth: {e.errors()}")
             continue

--- a/module/watchers/src/main.py
+++ b/module/watchers/src/main.py
@@ -126,11 +126,11 @@ def _zone_watcher_worker(
             else:
                 logger.info(f'ZONE {zone}: {m.name} is a free node')
                 count_of_free_machines = count_of_free_machines+1
- 
+
         if cluster_exists and not builds.should_retry_zone_build(zone, store_info.intent_hash):
             logger.info(f'Cluster already exists for {zone}. Skipping..')
             continue
- 
+
         if count_of_free_machines >= int(store_info.node_count):
             logger.info(f'ZONE {zone}: There are enough free  nodes to create cluster')
         else:
@@ -142,17 +142,27 @@ def _zone_watcher_worker(
         if zone_name_retrieved_from_api and not verify_zone_state(zone_state, zone_store_id, store_info.recreate_on_delete):
             logger.info(f'Zone: {zone}, Store: {store_id} is not in expected state! skipping..')
             continue
- 
+
         # Determine the try count for the next build.
         # If state is READY, it's a fresh start (or manual reset), so start at 1.
         # If state is STARTED, it's a continuation of an attempt, so increment from history.
+        # If state is ACTIVE (recreation), we start at 1 if the latest attempt succeeded (or no history). If the latest attempt failed, we increment from history.
         try_count = 1
-        if zone_state in (Zone.State.READY_FOR_CUSTOMER_FACTORY_TURNUP_CHECKS, Zone.State.ACTIVE):
+        if zone_state == Zone.State.READY_FOR_CUSTOMER_FACTORY_TURNUP_CHECKS:
             logger.info(f'Zone {zone} is in {zone_state.name} state. Starting with try_count=1.')
         elif zone_state == Zone.State.CUSTOMER_FACTORY_TURNUP_CHECKS_STARTED:
             latest_try = builds.get_latest_try_count(zone, store_info.intent_hash)
             try_count = latest_try + 1
             logger.info(f'Zone {zone} is in {zone_state.name} state. Latest try_count from history was {latest_try}. Setting next try_count={try_count}.')
+        elif zone_state == Zone.State.ACTIVE:
+            summary = builds.builds.get((zone, store_info.intent_hash))
+            if summary and summary.latest_attempt_failed:
+                latest_try = builds.get_latest_try_count(zone, store_info.intent_hash)
+                try_count = latest_try + 1
+                logger.info(f'Zone {zone} is in ACTIVE state and failed before. Setting next try_count={try_count}.')
+            else:
+                try_count = 1
+                logger.info(f'Zone {zone} is in ACTIVE state and has no recent failures. Starting with try_count=1.')
             
         # Pre-emptively skip if we have exceeded the allowed attempts (max_retries + 1).
         # This avoids triggering a build that we know will fail in the Bash script.

--- a/module/watchers/tests/test_build_history.py
+++ b/module/watchers/tests/test_build_history.py
@@ -26,8 +26,6 @@ class TestBuildSummary(unittest.TestCase):
     def test_initial_state(self):
         summary = BuildSummary()
         self.assertIsNone(summary.latestStatus)
-        self.assertEqual(summary.numberOfBuilds, 0)
-        self.assertEqual(summary.numberOfFailures, 0)
         self.assertFalse(summary.retriable)
         self.assertEqual(summary.latest_try_count, 0)
 
@@ -36,8 +34,6 @@ class TestBuildSummary(unittest.TestCase):
         build = create_mock_build("b1", Status.SUCCESS)
         summary.add_build(build)
         self.assertEqual(summary.latestStatus, Status.SUCCESS)
-        self.assertEqual(summary.numberOfBuilds, 1)
-        self.assertEqual(summary.numberOfFailures, 0)
         self.assertFalse(summary.retriable)
         self.assertEqual(summary.latest_try_count, 0)
 
@@ -47,8 +43,6 @@ class TestBuildSummary(unittest.TestCase):
         summary.add_build(build)
         # Note: latestStatus isn't updated on failure if it was None initially
         # self.assertEqual(summary.latestStatus, MockBuildStatus.FAILURE) # This depends on initial state logic
-        self.assertEqual(summary.numberOfBuilds, 1)
-        self.assertEqual(summary.numberOfFailures, 1)
         self.assertTrue(summary.retriable)
         self.assertEqual(summary.latest_try_count, 0)
 
@@ -57,8 +51,6 @@ class TestBuildSummary(unittest.TestCase):
         build = create_mock_build("b1", Status.WORKING)
         summary.add_build(build)
         self.assertEqual(summary.latestStatus, Status.WORKING)
-        self.assertEqual(summary.numberOfBuilds, 1)
-        self.assertEqual(summary.numberOfFailures, 0)
         self.assertFalse(summary.retriable)
         self.assertEqual(summary.latest_try_count, 0)
 
@@ -67,8 +59,6 @@ class TestBuildSummary(unittest.TestCase):
         build = create_mock_build("b1", Status.QUEUED)
         summary.add_build(build)
         self.assertEqual(summary.latestStatus, Status.QUEUED)
-        self.assertEqual(summary.numberOfBuilds, 1)
-        self.assertEqual(summary.numberOfFailures, 0)
         self.assertFalse(summary.retriable)
         self.assertEqual(summary.latest_try_count, 0)
 
@@ -77,8 +67,6 @@ class TestBuildSummary(unittest.TestCase):
         build = create_mock_build("b1", Status.PENDING)
         summary.add_build(build)
         self.assertEqual(summary.latestStatus, Status.PENDING)
-        self.assertEqual(summary.numberOfBuilds, 1)
-        self.assertEqual(summary.numberOfFailures, 0)
         self.assertFalse(summary.retriable)
         self.assertEqual(summary.latest_try_count, 0)
 
@@ -89,8 +77,6 @@ class TestBuildSummary(unittest.TestCase):
         summary.add_build(build_fail)
         summary.add_build(build_success) # Success overrides retriable
         self.assertEqual(summary.latestStatus, Status.SUCCESS)
-        self.assertEqual(summary.numberOfBuilds, 2)
-        self.assertEqual(summary.numberOfFailures, 1) # Failure count still increments
         self.assertFalse(summary.retriable)
         self.assertEqual(summary.latest_try_count, 0)
 
@@ -101,33 +87,7 @@ class TestBuildSummary(unittest.TestCase):
         summary.add_build(build_fail)
         summary.add_build(build_working) # Working overrides retriable
         self.assertEqual(summary.latestStatus, Status.WORKING)
-        self.assertEqual(summary.numberOfBuilds, 2)
-        self.assertEqual(summary.numberOfFailures, 1)
         self.assertFalse(summary.retriable)
-        self.assertEqual(summary.latest_try_count, 0)
-
-    def test_add_build_sequence_success_then_fail(self):
-        summary = BuildSummary()
-        build_success = create_mock_build("b1", Status.SUCCESS)
-        build_fail = create_mock_build("b2", Status.FAILURE)
-        summary.add_build(build_success)
-        summary.add_build(build_fail) # Failure after success doesn't change status/retriable
-        self.assertEqual(summary.latestStatus, Status.SUCCESS)
-        self.assertEqual(summary.numberOfBuilds, 2)
-        self.assertEqual(summary.numberOfFailures, 1) # Failure count still increments
-        self.assertFalse(summary.retriable) # Still False because latest was SUCCESS
-        self.assertEqual(summary.latest_try_count, 0)
-
-    def test_add_build_sequence_working_then_fail(self):
-        summary = BuildSummary()
-        build_working = create_mock_build("b1", Status.WORKING)
-        build_fail = create_mock_build("b2", Status.FAILURE)
-        summary.add_build(build_working)
-        summary.add_build(build_fail) # Failure after working doesn't change status/retriable
-        self.assertEqual(summary.latestStatus, Status.WORKING)
-        self.assertEqual(summary.numberOfBuilds, 2)
-        self.assertEqual(summary.numberOfFailures, 1)
-        self.assertFalse(summary.retriable) # Still False because latest was WORKING
         self.assertEqual(summary.latest_try_count, 0)
 
     def test_add_build_multiple_failures(self):
@@ -137,8 +97,6 @@ class TestBuildSummary(unittest.TestCase):
         summary.add_build(build1)
         summary.add_build(build2)
         # self.assertEqual(summary.latestStatus, MockBuildStatus.TIMEOUT) # Status doesn't update on failure if already failed
-        self.assertEqual(summary.numberOfBuilds, 2)
-        self.assertEqual(summary.numberOfFailures, 2)
         self.assertTrue(summary.retriable)
         self.assertEqual(summary.latest_try_count, 0)
 
@@ -250,15 +208,11 @@ class TestBuildHistory(unittest.TestCase):
 
         # Check zone-a summary (Failure then Success)
         summary_a = build_dict[("zone-a", "")]
-        self.assertEqual(summary_a.numberOfBuilds, 2)
-        self.assertEqual(summary_a.numberOfFailures, 1)
         self.assertEqual(summary_a.latestStatus, Status.SUCCESS)
         self.assertFalse(summary_a.retriable)
 
         # Check zone-b summary (Working then Failure)
         summary_b = build_dict[("zone-b", "")]
-        self.assertEqual(summary_b.numberOfBuilds, 2)
-        self.assertEqual(summary_b.numberOfFailures, 1)
         self.assertEqual(summary_b.latestStatus, Status.WORKING) # Working status persists
         self.assertFalse(summary_b.retriable)
 
@@ -301,6 +255,85 @@ class TestBuildHistory(unittest.TestCase):
         
         # Verify that it extracts the try count correctly!
         self.assertEqual(history.get_latest_try_count("zone-a", "hash-1"), 3)
+
+    @patch('src.build_history.BuildSummary')
+    def test_get_build_history_optimizes_traversal(self, MockBuildSummary, MockCloudBuildClient):
+        mock_client = MockCloudBuildClient.return_value
+        mock_trigger = MagicMock()
+        mock_trigger.name = self.trigger_name
+        mock_trigger.id = self.trigger_id
+        mock_client.list_build_triggers.return_value = [mock_trigger]
+
+        # Create builds for SAME zone and hash: Newest=SUCCESS, Older=FAILURE
+        build1 = create_mock_build("b1", Status.SUCCESS, {"_ZONE": "zone-a", "_INTENT_HASH": "hash-1"})
+        build2 = create_mock_build("b2", Status.FAILURE, {"_ZONE": "zone-a", "_INTENT_HASH": "hash-1"})
+
+        mock_client.list_builds.return_value = [build1, build2]
+
+        # Mock BuildSummary instance
+        mock_summary = MagicMock()
+        mock_summary.latestStatus = None
+        
+        def side_effect(build):
+            mock_summary.latestStatus = build.status
+            
+        mock_summary.add_build.side_effect = side_effect
+        MockBuildSummary.return_value = mock_summary
+
+        history = BuildHistory(self.project_id, self.region, self.max_retries, self.trigger_name)
+        
+        # Verify that add_build was only called ONCE!
+        self.assertEqual(mock_summary.add_build.call_count, 1)
+
+    def test_should_retry_independent_per_hash(self, MockCloudBuildClient):
+        mock_client = MockCloudBuildClient.return_value
+        mock_trigger = MagicMock()
+        mock_trigger.name = self.trigger_name
+        mock_trigger.id = self.trigger_id
+        mock_client.list_build_triggers.return_value = [mock_trigger]
+
+        # Create builds for SAME zone but DIFFERENT hashes
+        build1 = create_mock_build("b1", Status.FAILURE, {"_ZONE": "zone-a", "_INTENT_HASH": "hash-1"})
+        build2 = create_mock_build("b2", Status.SUCCESS, {"_ZONE": "zone-a", "_INTENT_HASH": "hash-2"})
+
+        mock_client.list_builds.return_value = [build2, build1]
+
+        history = BuildHistory(self.project_id, self.region, self.max_retries, self.trigger_name)
+
+        # Verify independent retry results
+        self.assertTrue(history.should_retry_zone_build("zone-a", "hash-1"))
+        self.assertFalse(history.should_retry_zone_build("zone-a", "hash-2"))
+
+    def test_get_build_history_backward_compatibility(self, MockCloudBuildClient):
+        mock_client = MockCloudBuildClient.return_value
+        mock_trigger = MagicMock()
+        mock_trigger.name = self.trigger_name
+        mock_trigger.id = self.trigger_id
+        mock_client.list_build_triggers.return_value = [mock_trigger]
+
+        # Create build WITHOUT _INTENT_HASH
+        build = create_mock_build("b1", Status.FAILURE, {"_ZONE": "zone-a"})
+
+        mock_client.list_builds.return_value = [build]
+
+        history = BuildHistory(self.project_id, self.region, self.max_retries, self.trigger_name)
+        build_dict = history.builds
+
+        # Verify it uses empty string as hash
+        self.assertIn(("zone-a", ""), build_dict)
+
+    def test_get_latest_try_count_empty_history(self, MockCloudBuildClient):
+        mock_client = MockCloudBuildClient.return_value
+        mock_trigger = MagicMock()
+        mock_trigger.name = self.trigger_name
+        mock_trigger.id = self.trigger_id
+        mock_client.list_build_triggers.return_value = [mock_trigger]
+        mock_client.list_builds.return_value = []
+
+        history = BuildHistory(self.project_id, self.region, self.max_retries, self.trigger_name)
+        
+        # Verify it returns 0 for non-existent history
+        self.assertEqual(history.get_latest_try_count("zone-a", "hash-1"), 0)
 
     def test_get_build_history_multiple_matching_triggers(self, MockCloudBuildClient):
         mock_client = MockCloudBuildClient.return_value

--- a/module/watchers/tests/test_build_history.py
+++ b/module/watchers/tests/test_build_history.py
@@ -25,7 +25,7 @@ class TestBuildSummary(unittest.TestCase):
 
     def test_initial_state(self):
         summary = BuildSummary()
-        self.assertIsNone(summary.latestStatus)
+        self.assertIsNone(summary.latest_non_failure_status)
         self.assertFalse(summary.retriable)
         self.assertEqual(summary.latest_try_count, 0)
 
@@ -33,7 +33,7 @@ class TestBuildSummary(unittest.TestCase):
         summary = BuildSummary()
         build = create_mock_build("b1", Status.SUCCESS)
         summary.add_build(build)
-        self.assertEqual(summary.latestStatus, Status.SUCCESS)
+        self.assertEqual(summary.latest_non_failure_status, Status.SUCCESS)
         self.assertFalse(summary.retriable)
         self.assertEqual(summary.latest_try_count, 0)
 
@@ -41,8 +41,8 @@ class TestBuildSummary(unittest.TestCase):
         summary = BuildSummary()
         build = create_mock_build("b1", Status.FAILURE)
         summary.add_build(build)
-        # Note: latestStatus isn't updated on failure if it was None initially
-        # self.assertEqual(summary.latestStatus, MockBuildStatus.FAILURE) # This depends on initial state logic
+        # Note: latest_non_failure_status isn't updated on failure if it was None initially
+        # self.assertEqual(summary.latest_non_failure_status, MockBuildStatus.FAILURE) # This depends on initial state logic
         self.assertTrue(summary.retriable)
         self.assertEqual(summary.latest_try_count, 0)
 
@@ -50,7 +50,7 @@ class TestBuildSummary(unittest.TestCase):
         summary = BuildSummary()
         build = create_mock_build("b1", Status.WORKING)
         summary.add_build(build)
-        self.assertEqual(summary.latestStatus, Status.WORKING)
+        self.assertEqual(summary.latest_non_failure_status, Status.WORKING)
         self.assertFalse(summary.retriable)
         self.assertEqual(summary.latest_try_count, 0)
 
@@ -58,7 +58,7 @@ class TestBuildSummary(unittest.TestCase):
         summary = BuildSummary()
         build = create_mock_build("b1", Status.QUEUED)
         summary.add_build(build)
-        self.assertEqual(summary.latestStatus, Status.QUEUED)
+        self.assertEqual(summary.latest_non_failure_status, Status.QUEUED)
         self.assertFalse(summary.retriable)
         self.assertEqual(summary.latest_try_count, 0)
 
@@ -66,7 +66,7 @@ class TestBuildSummary(unittest.TestCase):
         summary = BuildSummary()
         build = create_mock_build("b1", Status.PENDING)
         summary.add_build(build)
-        self.assertEqual(summary.latestStatus, Status.PENDING)
+        self.assertEqual(summary.latest_non_failure_status, Status.PENDING)
         self.assertFalse(summary.retriable)
         self.assertEqual(summary.latest_try_count, 0)
 
@@ -76,7 +76,7 @@ class TestBuildSummary(unittest.TestCase):
         build_success = create_mock_build("b2", Status.SUCCESS)
         summary.add_build(build_fail)
         summary.add_build(build_success) # Success overrides retriable
-        self.assertEqual(summary.latestStatus, Status.SUCCESS)
+        self.assertEqual(summary.latest_non_failure_status, Status.SUCCESS)
         self.assertFalse(summary.retriable)
         self.assertEqual(summary.latest_try_count, 0)
 
@@ -86,7 +86,7 @@ class TestBuildSummary(unittest.TestCase):
         build_working = create_mock_build("b2", Status.WORKING)
         summary.add_build(build_fail)
         summary.add_build(build_working) # Working overrides retriable
-        self.assertEqual(summary.latestStatus, Status.WORKING)
+        self.assertEqual(summary.latest_non_failure_status, Status.WORKING)
         self.assertFalse(summary.retriable)
         self.assertEqual(summary.latest_try_count, 0)
 
@@ -96,7 +96,7 @@ class TestBuildSummary(unittest.TestCase):
         build2 = create_mock_build("b2", Status.TIMEOUT)
         summary.add_build(build1)
         summary.add_build(build2)
-        # self.assertEqual(summary.latestStatus, MockBuildStatus.TIMEOUT) # Status doesn't update on failure if already failed
+        # self.assertEqual(summary.latest_non_failure_status, MockBuildStatus.TIMEOUT) # Status doesn't update on failure if already failed
         self.assertTrue(summary.retriable)
         self.assertEqual(summary.latest_try_count, 0)
 
@@ -208,12 +208,12 @@ class TestBuildHistory(unittest.TestCase):
 
         # Check zone-a summary (Failure then Success)
         summary_a = build_dict[("zone-a", "")]
-        self.assertEqual(summary_a.latestStatus, Status.SUCCESS)
+        self.assertEqual(summary_a.latest_non_failure_status, Status.SUCCESS)
         self.assertFalse(summary_a.retriable)
 
         # Check zone-b summary (Working then Failure)
         summary_b = build_dict[("zone-b", "")]
-        self.assertEqual(summary_b.latestStatus, Status.WORKING) # Working status persists
+        self.assertEqual(summary_b.latest_non_failure_status, Status.WORKING) # Working status persists
         self.assertFalse(summary_b.retriable)
 
         mock_client.list_builds.assert_called_once()
@@ -272,10 +272,10 @@ class TestBuildHistory(unittest.TestCase):
 
         # Mock BuildSummary instance
         mock_summary = MagicMock()
-        mock_summary.latestStatus = None
+        mock_summary.latest_non_failure_status = None
         
         def side_effect(build):
-            mock_summary.latestStatus = build.status
+            mock_summary.latest_non_failure_status = build.status
             
         mock_summary.add_build.side_effect = side_effect
         MockBuildSummary.return_value = mock_summary
@@ -284,6 +284,29 @@ class TestBuildHistory(unittest.TestCase):
         
         # Verify that add_build was only called ONCE!
         self.assertEqual(mock_summary.add_build.call_count, 1)
+
+    def test_latest_attempt_failed(self, MockCloudBuildClient):
+        mock_client = MockCloudBuildClient.return_value
+        mock_trigger = MagicMock()
+        mock_trigger.name = self.trigger_name
+        mock_trigger.id = self.trigger_id
+        mock_client.list_build_triggers.return_value = [mock_trigger]
+
+        # Test case 1: Newest build failed
+        build_fail = create_mock_build("b1", Status.FAILURE, {"_ZONE": "zone-a", "_INTENT_HASH": "hash-1"})
+        mock_client.list_builds.return_value = [build_fail]
+        
+        history = BuildHistory(self.project_id, self.region, self.max_retries, self.trigger_name)
+        summary = history.builds[("zone-a", "hash-1")]
+        self.assertTrue(summary.latest_attempt_failed)
+
+        # Test case 2: Newest build succeeded
+        build_success = create_mock_build("b2", Status.SUCCESS, {"_ZONE": "zone-b", "_INTENT_HASH": "hash-2"})
+        mock_client.list_builds.return_value = [build_success]
+        
+        history = BuildHistory(self.project_id, self.region, self.max_retries, self.trigger_name)
+        summary = history.builds[("zone-b", "hash-2")]
+        self.assertFalse(summary.latest_attempt_failed)
 
     def test_should_retry_independent_per_hash(self, MockCloudBuildClient):
         mock_client = MockCloudBuildClient.return_value

--- a/module/watchers/tests/test_build_history.py
+++ b/module/watchers/tests/test_build_history.py
@@ -29,6 +29,7 @@ class TestBuildSummary(unittest.TestCase):
         self.assertEqual(summary.numberOfBuilds, 0)
         self.assertEqual(summary.numberOfFailures, 0)
         self.assertFalse(summary.retriable)
+        self.assertEqual(summary.latest_try_count, 0)
 
     def test_add_build_success(self):
         summary = BuildSummary()
@@ -38,6 +39,7 @@ class TestBuildSummary(unittest.TestCase):
         self.assertEqual(summary.numberOfBuilds, 1)
         self.assertEqual(summary.numberOfFailures, 0)
         self.assertFalse(summary.retriable)
+        self.assertEqual(summary.latest_try_count, 0)
 
     def test_add_build_failure(self):
         summary = BuildSummary()
@@ -48,6 +50,7 @@ class TestBuildSummary(unittest.TestCase):
         self.assertEqual(summary.numberOfBuilds, 1)
         self.assertEqual(summary.numberOfFailures, 1)
         self.assertTrue(summary.retriable)
+        self.assertEqual(summary.latest_try_count, 0)
 
     def test_add_build_working(self):
         summary = BuildSummary()
@@ -57,6 +60,7 @@ class TestBuildSummary(unittest.TestCase):
         self.assertEqual(summary.numberOfBuilds, 1)
         self.assertEqual(summary.numberOfFailures, 0)
         self.assertFalse(summary.retriable)
+        self.assertEqual(summary.latest_try_count, 0)
 
     def test_add_build_queued(self):
         summary = BuildSummary()
@@ -66,6 +70,7 @@ class TestBuildSummary(unittest.TestCase):
         self.assertEqual(summary.numberOfBuilds, 1)
         self.assertEqual(summary.numberOfFailures, 0)
         self.assertFalse(summary.retriable)
+        self.assertEqual(summary.latest_try_count, 0)
 
     def test_add_build_pending(self):
         summary = BuildSummary()
@@ -75,6 +80,7 @@ class TestBuildSummary(unittest.TestCase):
         self.assertEqual(summary.numberOfBuilds, 1)
         self.assertEqual(summary.numberOfFailures, 0)
         self.assertFalse(summary.retriable)
+        self.assertEqual(summary.latest_try_count, 0)
 
     def test_add_build_sequence_fail_then_success(self):
         summary = BuildSummary()
@@ -86,6 +92,7 @@ class TestBuildSummary(unittest.TestCase):
         self.assertEqual(summary.numberOfBuilds, 2)
         self.assertEqual(summary.numberOfFailures, 1) # Failure count still increments
         self.assertFalse(summary.retriable)
+        self.assertEqual(summary.latest_try_count, 0)
 
     def test_add_build_sequence_fail_then_working(self):
         summary = BuildSummary()
@@ -97,6 +104,7 @@ class TestBuildSummary(unittest.TestCase):
         self.assertEqual(summary.numberOfBuilds, 2)
         self.assertEqual(summary.numberOfFailures, 1)
         self.assertFalse(summary.retriable)
+        self.assertEqual(summary.latest_try_count, 0)
 
     def test_add_build_sequence_success_then_fail(self):
         summary = BuildSummary()
@@ -108,6 +116,7 @@ class TestBuildSummary(unittest.TestCase):
         self.assertEqual(summary.numberOfBuilds, 2)
         self.assertEqual(summary.numberOfFailures, 1) # Failure count still increments
         self.assertFalse(summary.retriable) # Still False because latest was SUCCESS
+        self.assertEqual(summary.latest_try_count, 0)
 
     def test_add_build_sequence_working_then_fail(self):
         summary = BuildSummary()
@@ -119,6 +128,7 @@ class TestBuildSummary(unittest.TestCase):
         self.assertEqual(summary.numberOfBuilds, 2)
         self.assertEqual(summary.numberOfFailures, 1)
         self.assertFalse(summary.retriable) # Still False because latest was WORKING
+        self.assertEqual(summary.latest_try_count, 0)
 
     def test_add_build_multiple_failures(self):
         summary = BuildSummary()
@@ -130,27 +140,18 @@ class TestBuildSummary(unittest.TestCase):
         self.assertEqual(summary.numberOfBuilds, 2)
         self.assertEqual(summary.numberOfFailures, 2)
         self.assertTrue(summary.retriable)
-
-    def test_is_retriable_false_max_retries_exceeded(self):
-        summary = BuildSummary()
-        build1 = create_mock_build("b1", Status.FAILURE)
-        build2 = create_mock_build("b2", Status.INTERNAL_ERROR)
-        summary.add_build(build1)
-        summary.add_build(build2) # 2 failures
-        self.assertTrue(summary.is_retriable(max_retries=2))
-        self.assertFalse(summary.is_retriable(max_retries=1))
-        self.assertFalse(summary.is_retriable(max_retries=0))
+        self.assertEqual(summary.latest_try_count, 0)
 
     def test_is_retriable_false_not_retriable_state(self):
         summary = BuildSummary()
         build = create_mock_build("b1", Status.SUCCESS)
         summary.add_build(build)
-        self.assertFalse(summary.is_retriable(max_retries=1))
+        self.assertFalse(summary.retriable)
 
         summary = BuildSummary()
         build = create_mock_build("b1", Status.WORKING)
         summary.add_build(build)
-        self.assertFalse(summary.is_retriable(max_retries=1))
+        self.assertFalse(summary.retriable)
 
 
 @patch('google.cloud.devtools.cloudbuild.CloudBuildClient') # Patch the client in the module where it's used
@@ -243,25 +244,63 @@ class TestBuildHistory(unittest.TestCase):
         history = BuildHistory(self.project_id, self.region, self.max_retries, self.trigger_name)
         build_dict = history.builds
 
-        self.assertIn("zone-a", build_dict)
-        self.assertIn("zone-b", build_dict)
+        self.assertIn(("zone-a", ""), build_dict)
+        self.assertIn(("zone-b", ""), build_dict)
         self.assertEqual(len(build_dict), 2) # build4_no_zone should be skipped
 
         # Check zone-a summary (Failure then Success)
-        summary_a = build_dict["zone-a"]
+        summary_a = build_dict[("zone-a", "")]
         self.assertEqual(summary_a.numberOfBuilds, 2)
         self.assertEqual(summary_a.numberOfFailures, 1)
         self.assertEqual(summary_a.latestStatus, Status.SUCCESS)
         self.assertFalse(summary_a.retriable)
 
         # Check zone-b summary (Working then Failure)
-        summary_b = build_dict["zone-b"]
+        summary_b = build_dict[("zone-b", "")]
         self.assertEqual(summary_b.numberOfBuilds, 2)
         self.assertEqual(summary_b.numberOfFailures, 1)
         self.assertEqual(summary_b.latestStatus, Status.WORKING) # Working status persists
         self.assertFalse(summary_b.retriable)
 
         mock_client.list_builds.assert_called_once()
+
+    def test_get_build_history_groups_by_hash(self, MockCloudBuildClient):
+        mock_client = MockCloudBuildClient.return_value
+        mock_trigger = MagicMock()
+        mock_trigger.name = self.trigger_name
+        mock_trigger.id = self.trigger_id
+        mock_client.list_build_triggers.return_value = [mock_trigger]
+
+        # Create builds for SAME zone but DIFFERENT hashes
+        build1 = create_mock_build("b1", Status.FAILURE, {"_ZONE": "zone-a", "_INTENT_HASH": "hash-1"})
+        build2 = create_mock_build("b2", Status.SUCCESS, {"_ZONE": "zone-a", "_INTENT_HASH": "hash-2"})
+
+        mock_client.list_builds.return_value = [build2, build1]
+
+        history = BuildHistory(self.project_id, self.region, self.max_retries, self.trigger_name)
+        build_dict = history.builds
+
+        # Verify that it groups them separately!
+        self.assertIn(("zone-a", "hash-1"), build_dict)
+        self.assertIn(("zone-a", "hash-2"), build_dict)
+        self.assertEqual(len(build_dict), 2)
+
+    def test_get_build_history_extracts_try_count(self, MockCloudBuildClient):
+        mock_client = MockCloudBuildClient.return_value
+        mock_trigger = MagicMock()
+        mock_trigger.name = self.trigger_name
+        mock_trigger.id = self.trigger_id
+        mock_client.list_build_triggers.return_value = [mock_trigger]
+
+        # Create build with _TRY_COUNT
+        build = create_mock_build("b1", Status.FAILURE, {"_ZONE": "zone-a", "_INTENT_HASH": "hash-1", "_TRY_COUNT": "3"})
+
+        mock_client.list_builds.return_value = [build]
+
+        history = BuildHistory(self.project_id, self.region, self.max_retries, self.trigger_name)
+        
+        # Verify that it extracts the try count correctly!
+        self.assertEqual(history.get_latest_try_count("zone-a", "hash-1"), 3)
 
     def test_get_build_history_multiple_matching_triggers(self, MockCloudBuildClient):
         mock_client = MockCloudBuildClient.return_value
@@ -290,8 +329,8 @@ class TestBuildHistory(unittest.TestCase):
 
         history = BuildHistory(self.project_id, self.region, self.max_retries, self.trigger_name)
         # Zone 'zone-b' doesn't exist in history
-        self.assertFalse(history.should_retry_zone_build("zone-b"))
-        self.assertIn("zone-a", history.builds) # History should be populated
+        self.assertFalse(history.should_retry_zone_build("zone-b", ""))
+        self.assertIn(("zone-a", ""), history.builds) # History should be populated
 
     def test_should_retry_zone_build_is_retriable(self, MockCloudBuildClient):
         mock_client = MockCloudBuildClient.return_value
@@ -301,7 +340,7 @@ class TestBuildHistory(unittest.TestCase):
         mock_client.list_builds.return_value = [build1_zone1]
 
         history = BuildHistory(self.project_id, self.region, self.max_retries, self.trigger_name) # max_retries = 2
-        self.assertTrue(history.should_retry_zone_build("zone-a"))
+        self.assertTrue(history.should_retry_zone_build("zone-a", ""))
 
     def test_should_retry_zone_build_not_retriable_max_exceeded(self, MockCloudBuildClient):
         mock_client = MockCloudBuildClient.return_value
@@ -313,7 +352,7 @@ class TestBuildHistory(unittest.TestCase):
         mock_client.list_builds.return_value = [build3, build2, build1] # 3 failures
 
         history = BuildHistory(self.project_id, self.region, self.max_retries, self.trigger_name) # max_retries = 2
-        self.assertFalse(history.should_retry_zone_build("zone-a"))
+        self.assertTrue(history.should_retry_zone_build("zone-a", ""))
 
     def test_should_retry_zone_build_not_retriable_status_success(self, MockCloudBuildClient):
         mock_client = MockCloudBuildClient.return_value
@@ -324,7 +363,7 @@ class TestBuildHistory(unittest.TestCase):
         mock_client.list_builds.return_value = [build2, build1]
 
         history = BuildHistory(self.project_id, self.region, self.max_retries, self.trigger_name)
-        self.assertFalse(history.should_retry_zone_build("zone-a"))
+        self.assertFalse(history.should_retry_zone_build("zone-a", ""))
 
     def test_should_retry_zone_build_not_retriable_status_working(self, MockCloudBuildClient):
         mock_client = MockCloudBuildClient.return_value
@@ -335,7 +374,7 @@ class TestBuildHistory(unittest.TestCase):
         mock_client.list_builds.return_value = [build2, build1]
 
         history = BuildHistory(self.project_id, self.region, self.max_retries, self.trigger_name)
-        self.assertFalse(history.should_retry_zone_build("zone-a"))
+        self.assertFalse(history.should_retry_zone_build("zone-a", ""))
 
     def test_should_retry_zone_build_eager_load(self, MockCloudBuildClient):
         mock_client = MockCloudBuildClient.return_value
@@ -348,12 +387,12 @@ class TestBuildHistory(unittest.TestCase):
         self.assertIsNotNone(history.builds) # Should be loaded at init
 
         # First call
-        self.assertTrue(history.should_retry_zone_build("zone-a"))
+        self.assertTrue(history.should_retry_zone_build("zone-a", ""))
         mock_client.list_builds.assert_called_once()
 
         # Second call - uses cached history
         mock_client.list_builds.reset_mock() # Reset mock call count
-        self.assertTrue(history.should_retry_zone_build("zone-a"))
+        self.assertTrue(history.should_retry_zone_build("zone-a", ""))
         mock_client.list_builds.assert_not_called() # Should not call again
 
     def test_should_retry_zone_build_missing_zone_name(self, MockCloudBuildClient):
@@ -366,6 +405,6 @@ class TestBuildHistory(unittest.TestCase):
 
         history = BuildHistory(self.project_id, self.region, self.max_retries, self.trigger_name)
         with self.assertRaisesRegex(Exception, 'missing zone_name'):
-            history.should_retry_zone_build(None)
+            history.should_retry_zone_build(None, "")
         with self.assertRaisesRegex(Exception, 'missing zone_name'):
-            history.should_retry_zone_build("")
+            history.should_retry_zone_build("", "")

--- a/module/watchers/tests/test_build_history.py
+++ b/module/watchers/tests/test_build_history.py
@@ -29,73 +29,73 @@ class TestBuildSummary(unittest.TestCase):
         self.assertFalse(summary.retriable)
         self.assertEqual(summary.latest_try_count, 0)
 
-    def test_add_build_success(self):
+    def test_flag_first_non_failure_build_success(self):
         summary = BuildSummary()
         build = create_mock_build("b1", Status.SUCCESS)
-        summary.add_build(build)
+        summary.flag_first_non_failure_build(build)
         self.assertEqual(summary.latest_non_failure_status, Status.SUCCESS)
         self.assertFalse(summary.retriable)
         self.assertEqual(summary.latest_try_count, 0)
 
-    def test_add_build_failure(self):
+    def test_flag_first_non_failure_build_failure(self):
         summary = BuildSummary()
         build = create_mock_build("b1", Status.FAILURE)
-        summary.add_build(build)
+        summary.flag_first_non_failure_build(build)
         # Note: latest_non_failure_status isn't updated on failure if it was None initially
         # self.assertEqual(summary.latest_non_failure_status, MockBuildStatus.FAILURE) # This depends on initial state logic
         self.assertTrue(summary.retriable)
         self.assertEqual(summary.latest_try_count, 0)
 
-    def test_add_build_working(self):
+    def test_flag_first_non_failure_build_working(self):
         summary = BuildSummary()
         build = create_mock_build("b1", Status.WORKING)
-        summary.add_build(build)
+        summary.flag_first_non_failure_build(build)
         self.assertEqual(summary.latest_non_failure_status, Status.WORKING)
         self.assertFalse(summary.retriable)
         self.assertEqual(summary.latest_try_count, 0)
 
-    def test_add_build_queued(self):
+    def test_flag_first_non_failure_build_queued(self):
         summary = BuildSummary()
         build = create_mock_build("b1", Status.QUEUED)
-        summary.add_build(build)
+        summary.flag_first_non_failure_build(build)
         self.assertEqual(summary.latest_non_failure_status, Status.QUEUED)
         self.assertFalse(summary.retriable)
         self.assertEqual(summary.latest_try_count, 0)
 
-    def test_add_build_pending(self):
+    def test_flag_first_non_failure_build_pending(self):
         summary = BuildSummary()
         build = create_mock_build("b1", Status.PENDING)
-        summary.add_build(build)
+        summary.flag_first_non_failure_build(build)
         self.assertEqual(summary.latest_non_failure_status, Status.PENDING)
         self.assertFalse(summary.retriable)
         self.assertEqual(summary.latest_try_count, 0)
 
-    def test_add_build_sequence_fail_then_success(self):
+    def test_flag_first_non_failure_build_sequence_fail_then_success(self):
         summary = BuildSummary()
         build_fail = create_mock_build("b1", Status.FAILURE)
         build_success = create_mock_build("b2", Status.SUCCESS)
-        summary.add_build(build_fail)
-        summary.add_build(build_success) # Success overrides retriable
+        summary.flag_first_non_failure_build(build_fail)
+        summary.flag_first_non_failure_build(build_success) # Success overrides retriable
         self.assertEqual(summary.latest_non_failure_status, Status.SUCCESS)
         self.assertFalse(summary.retriable)
         self.assertEqual(summary.latest_try_count, 0)
 
-    def test_add_build_sequence_fail_then_working(self):
+    def test_flag_first_non_failure_build_sequence_fail_then_working(self):
         summary = BuildSummary()
         build_fail = create_mock_build("b1", Status.FAILURE)
         build_working = create_mock_build("b2", Status.WORKING)
-        summary.add_build(build_fail)
-        summary.add_build(build_working) # Working overrides retriable
+        summary.flag_first_non_failure_build(build_fail)
+        summary.flag_first_non_failure_build(build_working) # Working overrides retriable
         self.assertEqual(summary.latest_non_failure_status, Status.WORKING)
         self.assertFalse(summary.retriable)
         self.assertEqual(summary.latest_try_count, 0)
 
-    def test_add_build_multiple_failures(self):
+    def test_flag_first_non_failure_build_multiple_failures(self):
         summary = BuildSummary()
         build1 = create_mock_build("b1", Status.FAILURE)
         build2 = create_mock_build("b2", Status.TIMEOUT)
-        summary.add_build(build1)
-        summary.add_build(build2)
+        summary.flag_first_non_failure_build(build1)
+        summary.flag_first_non_failure_build(build2)
         # self.assertEqual(summary.latest_non_failure_status, MockBuildStatus.TIMEOUT) # Status doesn't update on failure if already failed
         self.assertTrue(summary.retriable)
         self.assertEqual(summary.latest_try_count, 0)
@@ -103,12 +103,12 @@ class TestBuildSummary(unittest.TestCase):
     def test_is_retriable_false_not_retriable_state(self):
         summary = BuildSummary()
         build = create_mock_build("b1", Status.SUCCESS)
-        summary.add_build(build)
+        summary.flag_first_non_failure_build(build)
         self.assertFalse(summary.retriable)
 
         summary = BuildSummary()
         build = create_mock_build("b1", Status.WORKING)
-        summary.add_build(build)
+        summary.flag_first_non_failure_build(build)
         self.assertFalse(summary.retriable)
 
 
@@ -277,13 +277,13 @@ class TestBuildHistory(unittest.TestCase):
         def side_effect(build):
             mock_summary.latest_non_failure_status = build.status
             
-        mock_summary.add_build.side_effect = side_effect
+        mock_summary.flag_first_non_failure_build.side_effect = side_effect
         MockBuildSummary.return_value = mock_summary
 
         history = BuildHistory(self.project_id, self.region, self.max_retries, self.trigger_name)
         
-        # Verify that add_build was only called ONCE!
-        self.assertEqual(mock_summary.add_build.call_count, 1)
+        # Verify that flag_first_non_failure_build was only called ONCE!
+        self.assertEqual(mock_summary.flag_first_non_failure_build.call_count, 1)
 
     def test_latest_attempt_failed(self, MockCloudBuildClient):
         mock_client = MockCloudBuildClient.return_value


### PR DESCRIPTION
# feat: implement granular retry logic using intent hashing and attempt counters for cluster builds

## Problem
The previous retry logic for cluster provisioning had several issues that blocked customers (like McD) from enabling automatic retries in production:
1. **Metric Discrepancy**: The Python `zone-watcher` counted only failures, while the Bash script in `create-cluster.yaml` counted all attempts using `gcloud builds list`. This led to inconsistent behavior.
2. **Lack of Lifecycle Reset**: Retries were calculated based on the full build history. If a cluster succeeded in the past, was deleted, and then recreated, old successful builds or failures were counted against the new attempt, causing premature failures.
3. **Performance**: Calling `gcloud builds list` in the Bash script was slow and prone to race conditions.

## Solution
This PR introduces a more robust and granular retry tracking system based on **Content Hashing**, **Zone State detection**, and **Explicit Try Counting**.

### Key Concepts:
- **Content Hashing**: We calculate a SHA256 hash of the cluster intent configuration (CSV row). Retries are now scoped to specific configurations.
- **State-Based Reset**: When a Zone is manually reset to `READY_FOR_CUSTOMER_FACTORY_TURNUP_CHECKS`, the system interprets it as a fresh start and resets the try count to 1, regardless of history.
- **Explicit Try Counting**: Python calculates the next `try_count` based on history and state, and passes it to Cloud Build as a substitution (`_TRY_COUNT`). The Bash script uses this value directly, eliminating the need for `gcloud` list calls.

## Changes

### Watchers

#### `main.py`
- Added calculation of SHA256 hash for CSV rows to track configuration changes.
- Implemented state-based `try_count` calculation (`READY` -> 1, `STARTED` -> increment).
- Added pre-emptive skip in Python if `try_count` exceeds allowed attempts to save resources.
- Passed `_INTENT_HASH` and `_TRY_COUNT` to Cloud Build.

#### `build_history.py`
- Updated `BuildSummary` to store `latest_try_count` and grouped builds by `(zone, intent_hash)`.
- Removed redundant failure counting logic as limits are now checked via `_TRY_COUNT` in `main.py`.

### Bootstrap

#### `create-cluster.yaml`
- Removed `gcloud builds list` from the `die` function.
- Used the passed `$TRY_COUNT` directly to check against `$MAX_RETRIES`.
- Added `TRY_COUNT` and `INTENT_HASH` to the `env:` section.

## Verification
Verified the solution across the following 7 scenarios:
1. **Brand New Cluster Creation**: Starts at `_TRY_COUNT="1"`.
2. **Automatic Retry on Failure**: Increments to `_TRY_COUNT="2"` on subsequent failure.
3. **Max Retries Interception (Python)**: Stops triggering builds when limit reached.
4. **Manual Reset**: Setting Zone state back to `READY` resets `try_count` to 1.
5. **Configuration Change**: Changing CSV data changes hash and resets `try_count` to 1.
6. **Zero Max Retries Behavior**: Setting `MAX_RETRIES` to 0 fails immediately on first error.
7. **Recreation after Deletion**: Deleting an active cluster resets `try_count` to 1 for recreation.
- When the edge zone is in ACTIVE state, zone signal will be disabled since machines and clusters are already installed in cx store and billing starts, we need to make sure with ACTIVE state, max retry logic would also work.
Here are the test logs
```
# First run in Zone Watcher
Found latest build for zone us-central1-edge-bjc66013 with hash 60a3a83b73673c53fee346ca30585a3d1136f8face2c22edaf0bdf965e1be268. Latest try_count=1

Store: projects/edgesites-baremetal-lab-qual/locations/us-central1/zones/gmec-bjc90 was already setup, but specified to recreate on delete!

Zone us-central1-edge-bjc66013 is in ACTIVE state. Starting with try_count=1.

# First Cloud Build, try count is 1.
>>> [ERROR] Current try count 1 is <= max retries 5. Skipping failure signal to allow next retry.

# Ignore 2th run - 5th run logs, they are the same.

# Sixth run in Zone Watcher
Store: projects/edgesites-baremetal-lab-qual/locations/us-central1/zones/gmec-bjc90 was already setup, but specified to recreate on delete!

Zone us-central1-edge-bjc66013 is in ACTIVE state and failed before. Setting next try_count=6.

# Sixth Cloud Build
>>> [ERROR] Current try count 6 has exhausted max retries 5. Marking zone as failed
>>> [Zone Signal] Aborted: UNDER_FACTORY_CHECKS is FALSE
```
