### PR TITLE
feat(watcher): add the network_connection_heartbeat for networking failures detection

### DIFF
--- a/module/alerts.tf
+++ b/module/alerts.tf
@@ -113,6 +113,33 @@ resource "google_monitoring_alert_policy" "watcher-absence-alert" {
   }
 }
 
+resource "google_monitoring_alert_policy" "network-heartbeat-failure-alert" {
+  display_name = "ACP Network Heartbeat Failure - ${var.environment}"
+  combiner     = "OR"
+  notification_channels = [google_monitoring_notification_channel.cp_notification_channel.name]
+  conditions {
+    display_name = "Network unreachable for project"
+    condition_threshold {
+      filter          = "metric.type=\"custom.googleapis.com/acp_network_heartbeat\" AND resource.type=\"global\""
+      duration        = "1500s" # 25 minutes
+      comparison      = "COMPARISON_LT"
+      threshold_value = 1
+      
+      aggregations {
+        alignment_period   = "600s" # 10 minutes (matches scheduler)
+        per_series_aligner = "ALIGN_MEAN"
+        cross_series_reducer = "REDUCE_NONE"
+        group_by_fields    = ["metric.label.target_project_id", "metric.label.target_type"]
+      }
+    }
+  }
+
+  documentation {
+    content   = "The ACP network heartbeat has failed to reach target project $${metric.label.target_project_id}. Please check network connectivity and permissions."
+    mime_type = "text/markdown"
+  }
+}
+
 
 
 resource "time_sleep" "cluster-creation-failure-healthcheck-timer" {

--- a/module/main.tf
+++ b/module/main.tf
@@ -509,3 +509,68 @@ resource "google_cloud_scheduler_job" "zone-active-metric-job" {
     }
   }
 }
+
+# Network Connection Heartbeat cloud function
+resource "google_cloudfunctions2_function" "network-connection-heartbeat" {
+  name        = "network-connection-heartbeat-${var.environment}"
+  location    = var.region
+  description = "Network connection heartbeat function"
+
+  build_config {
+    runtime     = "python312"
+    entry_point = "network_connection_heartbeat"
+    environment_variables = {
+      "SOURCE_SHA" = data.archive_file.watcher-src.output_sha
+    }
+    service_account = google_service_account.zone-watcher-builder.id
+    source {
+      storage_source {
+        bucket = google_storage_bucket.gdce-cluster-provisioner-bucket.name
+        object = google_storage_bucket_object.watcher-src.name
+      }
+    }
+  }
+
+  service_config {
+    max_instance_count = 1
+    available_memory   = "256M"
+    timeout_seconds    = 60
+    environment_variables = {
+      GOOGLE_CLOUD_PROJECT                      = var.project_id,
+      REGION                                    = var.region
+      SOURCE_OF_TRUTH_REPO                      = var.source_of_truth_repo
+      SOURCE_OF_TRUTH_BRANCH                    = var.source_of_truth_branch
+      SOURCE_OF_TRUTH_PATH                      = var.source_of_truth_path
+      PROJECT_ID_SECRETS                        = var.project_id_secrets
+      GIT_SECRET_ID                             = var.git_secret_id
+    }
+    service_account_email = google_service_account.zone-watcher-agent.email
+    vpc_connector         = var.vpc_connector
+    vpc_connector_egress_settings = var.vpc_connector_egress_settings
+  }
+}
+
+resource "google_cloud_run_service_iam_member" "network-connection-heartbeat-member" {
+  location = google_cloudfunctions2_function.network-connection-heartbeat.location
+  service  = google_cloudfunctions2_function.network-connection-heartbeat.name
+  role     = "roles/run.invoker"
+  member   = google_service_account.gdce-provisioning-agent.member
+}
+
+resource "google_cloud_scheduler_job" "network-connection-heartbeat-job" {
+  name             = "network-connection-heartbeat-scheduler-${var.environment}"
+  description      = "Trigger the ${google_cloudfunctions2_function.network-connection-heartbeat.name}"
+  schedule         = "*/10 * * * *" # Run every 10 minutes
+  time_zone        = "Europe/Dublin"
+  attempt_deadline = "320s"
+  region           = var.region
+
+  http_target {
+    http_method = "POST"
+    uri         = google_cloudfunctions2_function.network-connection-heartbeat.service_config[0].uri
+
+    oidc_token {
+      service_account_email = google_service_account.gdce-provisioning-agent.email
+    }
+  }
+}

--- a/module/watchers/src/main.py
+++ b/module/watchers/src/main.py
@@ -202,6 +202,9 @@ def _zone_watcher_worker(
 @functions_framework.http
 def zone_watcher(req: flask.Request):
     params = WatcherSettings()
+    
+    if not params.cloud_build_trigger_name:
+        raise ValueError("CB_TRIGGER_NAME environment variable is required for zone_watcher")
 
     logger.info(f'Running zone watcher for: proj_id={params.project_id},sot={params.source_of_truth_repo}/{params.source_of_truth_branch}/{params.source_of_truth_path}, cb_trigger={params.cloud_build_trigger}')
     
@@ -414,6 +417,9 @@ def _cluster_watcher_worker(
 @functions_framework.http
 def cluster_watcher(req: flask.Request):
     params = WatcherSettings()
+    
+    if not params.cloud_build_trigger_name:
+        raise ValueError("CB_TRIGGER_NAME environment variable is required for cluster_watcher")
 
     logger.info(f'proj_id = {params.project_id}')
     logger.info(f'cb_trigger = {params.cloud_build_trigger}')
@@ -460,22 +466,24 @@ def zone_active_metric(req: flask.Request):
         b_generate_metric = False
         b_zone_found = False
         active_metric = 0  # 0 - inactive, 1 - active
-        if (m_proj_id, loc) not in zones_project_locations_checked:
-            zones.update(get_zones(m_proj_id, loc))
-            zones_project_locations_checked.add((m_proj_id, loc))   
-
         try:
+            if (m_proj_id, loc) not in zones_project_locations_checked:
+                zones.update(get_zones(m_proj_id, loc))
+                zones_project_locations_checked.add((m_proj_id, loc))   
+
             zone = zones[store_id]
             logger.debug(f'{store_id} state = {Zone.State(zone.state).name}')
             b_zone_found = True
         except Exception as e:
             logger.debug(f'get_zone({store_id}) -> {type(e)}', exc_info=False)
             if isinstance(e, exceptions.ServerError):
+                logger.error(f"API Failure calling get_zones for project {m_proj_id}: {e}")
                 # if ServerError (API failure), treat zone as active and not to filter any alerts
                 # any exception other than hw mgmt API failure, such as ClientError or generic exception
                 # treat as non-existing zone (don't generate metric)
                 b_generate_metric = True
                 active_metric = 1
+                gdce_zone_name = store_id  # Fallback to avoid UnboundLocalError if API fails
 
         if b_zone_found and zone.globally_unique_id is not None and len(zone.globally_unique_id.strip()) > 0:
             # only zones with globally_unique_id is considering as existing zones(generate metric)
@@ -531,6 +539,106 @@ def zone_active_metric(req: flask.Request):
     logger.debug(f'total zone active flag updated = {len(time_series_data)}')
     return f'total zone active flag updated = {len(time_series_data)}'
 
+@functions_framework.http
+def network_connection_heartbeat(req: flask.Request):
+    params = WatcherSettings()
+    logger.info(f'Running Network Connection Heartbeat in: proj_id={params.project_id}')
+
+    def create_time_series_point(project_id, target_project_id, location, target_type, status):
+        timestamp = Timestamp()
+        timestamp.GetCurrentTime()
+        
+        data_point = {
+            'interval': {'end_time': timestamp},
+            'value': {'int64_value': status}
+        }
+        
+        return {
+            'metric': {
+                'type': 'custom.googleapis.com/acp_network_heartbeat',
+                'labels': {
+                    'target_project_id': target_project_id,
+                    'location': location,
+                    'target_type': target_type
+                }
+            },
+            'resource': {
+                'type': 'global',
+                'labels': {
+                    'project_id': project_id
+                }
+            },
+            'points': [data_point]
+        }
+
+    token = get_git_token_from_secrets_manager(params.secrets_project_id, params.git_secret_id)
+    intent_reader = ClusterIntentReader(
+        params.source_of_truth_repo, params.source_of_truth_branch,
+        params.source_of_truth_path, token)
+    zone_config_fio = intent_reader.retrieve_source_of_truth()
+    rdr = csv.DictReader(io.StringIO(zone_config_fio))
+
+    time_series_data = []
+    machine_projects_checked = set()
+    fleet_projects_checked = set()
+
+    for row in rdr:
+        f_proj_id = row['fleet_project_id']
+        m_proj_id = f_proj_id if row['machine_project_id'] is None or len(row['machine_project_id']) == 0 else row['machine_project_id']
+        loc = params.region if row['location'] is None or len(row['location']) == 0 else row['location']
+        
+        # 1. Check Machine Project (HWM API)
+        if (m_proj_id, loc) not in machine_projects_checked:
+            machine_projects_checked.add((m_proj_id, loc))
+            status = 0
+            try:
+                hwm_client = clients.get_hardware_management_client()
+                hwm_client.list_zones(request={"parent": f"projects/{m_proj_id}/locations/{loc}"})
+                status = 1
+            except Exception as e:
+                logger.error(f"Network check failed for Machine Project {m_proj_id}/{loc}: {e}")
+            
+            time_series_data.append(create_time_series_point(
+                project_id=params.project_id,
+                target_project_id=m_proj_id,
+                location=loc,
+                target_type="machine_project",
+                status=status
+            ))
+
+        # 2. Check Fleet Project (Edge Container API)
+        if (f_proj_id, loc) not in fleet_projects_checked:
+            fleet_projects_checked.add((f_proj_id, loc))
+            status = 0
+            try:
+                ec_client = clients.get_edgecontainer_client()
+                ec_client.list_clusters(request={"parent": f"projects/{f_proj_id}/locations/{loc}"})
+                status = 1
+            except Exception as e:
+                logger.error(f"Network check failed for Fleet Project {f_proj_id}/{loc}: {e}")
+            
+            time_series_data.append(create_time_series_point(
+                project_id=params.project_id,
+                target_project_id=f_proj_id,
+                location=loc,
+                target_type="fleet_project",
+                status=status
+            ))
+
+    # Send to Cloud Monitoring
+    m_client = clients.get_monitoring_client()
+    batch_size = 200
+    for i in range(0, len(time_series_data), batch_size):
+        request = monitoring_v3.CreateTimeSeriesRequest({
+            'name': f'projects/{params.project_id}',
+            'time_series': time_series_data[i:i + batch_size]
+        })
+        m_client.create_time_series(request)
+
+    logger.info(f'Total network heartbeat points updated = {len(time_series_data)}')
+    return f'Total network heartbeat points updated = {len(time_series_data)}'
+
+
 def read_intent_data(params, named_key) -> Dict[Tuple, Dict[str, SourceOfTruthModel]]:
     """Returns a data structure containing project, location, and store information  
 
@@ -557,14 +665,17 @@ def read_intent_data(params, named_key) -> Dict[Tuple, Dict[str, SourceOfTruthMo
     rdr = csv.DictReader(io.StringIO(zone_config_fio))  # will raise exception if csv parsing fails
     
     # Read fleet config for fleet-level version verification
-    fleet_reader = ClusterIntentReader(params.source_of_truth_repo, params.source_of_truth_branch, params.fleet_config_path, token)
     fleet_versions = {}
-    try:
-        fleet_config_fio = fleet_reader.retrieve_source_of_truth()
-        fleet_rdr = csv.DictReader(io.StringIO(fleet_config_fio))
-    except Exception as e:
-        logger.warning(f"Failed to read fleet config file at {params.fleet_config_path}: {e}. Fleet-level version validation will be skipped.")
-        fleet_rdr = []
+    fleet_rdr = []
+    if params.fleet_config_path:
+        fleet_reader = ClusterIntentReader(params.source_of_truth_repo, params.source_of_truth_branch, params.fleet_config_path, token)
+        try:
+            fleet_config_fio = fleet_reader.retrieve_source_of_truth()
+            fleet_rdr = csv.DictReader(io.StringIO(fleet_config_fio))
+        except Exception as e:
+            logger.warning(f"Failed to read fleet config file at {params.fleet_config_path}: {e}. Fleet-level version validation will be skipped.")
+    else:
+        logger.info("Fleet config path not provided. Fleet-level version validation will be skipped.")
 
     for f_row in fleet_rdr:
         try:

--- a/module/watchers/src/watcher_settings.py
+++ b/module/watchers/src/watcher_settings.py
@@ -10,8 +10,8 @@ class WatcherSettings(BaseSettings):
     source_of_truth_repo: str = Field(..., alias="SOURCE_OF_TRUTH_REPO")
     source_of_truth_branch: str = Field(..., alias="SOURCE_OF_TRUTH_BRANCH")
     source_of_truth_path: str = Field(..., alias="SOURCE_OF_TRUTH_PATH")
-    fleet_config_path: str = Field(..., alias="FLEET_CONFIG_PATH")
-    cloud_build_trigger_name: str = Field(..., alias="CB_TRIGGER_NAME")
+    fleet_config_path: Optional[str] = Field(default=None, alias="FLEET_CONFIG_PATH")
+    cloud_build_trigger_name: Optional[str] = Field(default=None, alias="CB_TRIGGER_NAME")
     max_retries: int = Field(default=0, ge=0, le=5, alias="MAX_RETRIES")
     max_workers: int = Field(default=1, ge=1, le=100, alias="MAX_WORKERS")
 

--- a/module/watchers/tests/test_main.py
+++ b/module/watchers/tests/test_main.py
@@ -138,6 +138,36 @@ project1,1.12.0
 
     @mock.patch('src.main.get_git_token_from_secrets_manager')
     @mock.patch('src.main.ClusterIntentReader')
+    def test_read_intent_data_no_fleet_config(self, mock_reader_cls, mock_get_token):
+        """Test that when fleet_config_path is None, fleet version validation is skipped but parsing continues."""
+        mock_get_token.return_value = "mock-token"
+        mock_reader_instance = mock.MagicMock()
+        mock_reader_cls.return_value = mock_reader_instance
+        
+        main_csv = """store_id,fleet_project_id,machine_project_id,location,cluster_name,node_count,cluster_ipv4_cidr,services_ipv4_cidr,external_load_balancer_ipv4_address_pools,sync_repo,sync_branch,sync_dir,secrets_project_id,git_token_secrets_manager_name,cluster_version
+store1,project1,machine1,us-central1,cluster1,3,10.0.0.0/16,10.1.0.0/16,1.1.1.1-1.1.1.10,repo1,main,.,sec-proj,git-sec,"1.13.0"
+"""
+        mock_reader_instance.retrieve_source_of_truth.return_value = main_csv
+        
+        params = mock.MagicMock()
+        params.source_of_truth_repo = "repo"
+        params.source_of_truth_branch = "main"
+        params.source_of_truth_path = "intent.csv"
+        params.fleet_config_path = None
+        params.secrets_project_id = "sec-proj"
+        params.git_secret_id = "git-sec"
+        
+        result = main.read_intent_data(params, 'fleet_project_id')
+        
+        self.assertIn(('project1', 'us-central1'), result)
+        self.assertIn('store1', result[('project1', 'us-central1')])
+        edge_zone = result[('project1', 'us-central1')]['store1']
+        self.assertEqual(edge_zone.cluster_version, "1.13.0")
+        # Assert ClusterIntentReader was only instantiated once (for the main CSV)
+        mock_reader_cls.assert_called_once_with("repo", "main", "intent.csv", "mock-token")
+
+    @mock.patch('src.main.get_git_token_from_secrets_manager')
+    @mock.patch('src.main.ClusterIntentReader')
     def test_read_intent_data_robin_cns_invalid_version(self, mock_reader_cls, mock_get_token):
         """Test that Robin CNS validation fails if version is below 1.12.0."""
         mock_get_token.return_value = "mock-token"
@@ -163,3 +193,117 @@ project1,1.11.0
         result = main.read_intent_data(params, 'fleet_project_id')
         
         self.assertEqual(result.get(('project1', 'us-central1')), {})
+
+
+class TestZoneActiveMetric(unittest.TestCase):
+
+    @mock.patch('src.main.clients.get_monitoring_client')
+    @mock.patch('src.main.get_zones')
+    @mock.patch('src.main.ClusterIntentReader')
+    @mock.patch('src.main.get_git_token_from_secrets_manager')
+    @mock.patch('src.main.WatcherSettings')
+    def test_zone_active_metric_api_failure(
+        self,
+        mock_watcher_settings,
+        mock_get_git_token,
+        mock_intent_reader_class,
+        mock_get_zones,
+        mock_get_monitoring_client,
+    ):
+        from google.api_core import exceptions
+        
+        # Arrange
+        params = mock.MagicMock()
+        params.project_id = "test-project"
+        params.secrets_project_id = "test-secrets-project"
+        params.git_secret_id = "test-git-secret"
+        mock_watcher_settings.return_value = params
+
+        mock_get_git_token.return_value = "test-token"
+
+        mock_intent_reader = mock.MagicMock()
+        mock_intent_reader_class.return_value = mock_intent_reader
+        mock_intent_reader.retrieve_source_of_truth.return_value = (
+            "fleet_project_id,location,store_id,cluster_name,machine_project_id\n"
+            "test-fleet-project,test-location,store1,cluster1,test-machine-project\n"
+        )
+
+        mock_get_zones.side_effect = exceptions.ServerError("API down")
+
+        mock_m_client = mock.MagicMock()
+        mock_get_monitoring_client.return_value = mock_m_client
+
+        # Act
+        req = mock.MagicMock()
+        main.zone_active_metric(req)
+
+        # Assert
+        mock_m_client.create_time_series.assert_called_once()
+        args, kwargs = mock_m_client.create_time_series.call_args
+        request = args[0]
+        
+        self.assertEqual(request.time_series[0].points[0].value.int64_value, 1)
+
+
+class TestNetworkConnectionHeartbeat(unittest.TestCase):
+
+    @mock.patch('src.main.clients.get_monitoring_client')
+    @mock.patch('src.main.clients.get_edgenetwork_client')
+    @mock.patch('src.main.clients.get_edgecontainer_client')
+    @mock.patch('src.main.clients.get_hardware_management_client')
+    @mock.patch('src.main.ClusterIntentReader')
+    @mock.patch('src.main.get_git_token_from_secrets_manager')
+    @mock.patch('src.main.WatcherSettings')
+    def test_network_connection_heartbeat_success(
+        self,
+        mock_watcher_settings,
+        mock_get_git_token,
+        mock_intent_reader_class,
+        mock_get_hwm_client,
+        mock_get_ec_client,
+        mock_get_en_client,
+        mock_get_monitoring_client,
+    ):
+        from google.api_core import exceptions
+        
+        # Arrange
+        params = mock.MagicMock()
+        params.project_id = "test-project"
+        params.secrets_project_id = "test-secrets-project"
+        params.git_secret_id = "test-git-secret"
+        mock_watcher_settings.return_value = params
+
+        mock_get_git_token.return_value = "test-token"
+
+        mock_intent_reader = mock.MagicMock()
+        mock_intent_reader_class.return_value = mock_intent_reader
+        mock_intent_reader.retrieve_source_of_truth.return_value = (
+            "fleet_project_id,location,store_id,cluster_name,machine_project_id\n"
+            "test-fleet-project,test-location,store1,cluster1,test-machine-project\n"
+        )
+
+        mock_hwm_client = mock.MagicMock()
+        mock_get_hwm_client.return_value = mock_hwm_client
+        
+        mock_ec_client = mock.MagicMock()
+        mock_get_ec_client.return_value = mock_ec_client
+        
+        mock_en_client = mock.MagicMock()
+        mock_get_en_client.return_value = mock_en_client
+
+        mock_m_client = mock.MagicMock()
+        mock_get_monitoring_client.return_value = mock_m_client
+
+        # Act
+        req = mock.MagicMock()
+        main.network_connection_heartbeat(req)
+
+        # Assert
+        mock_m_client.create_time_series.assert_called_once()
+        args, kwargs = mock_m_client.create_time_series.call_args
+        request = args[0]
+        
+        self.assertEqual(len(request.time_series), 2)
+        for ts in request.time_series:
+            self.assertEqual(ts.points[0].value.int64_value, 1)
+


### PR DESCRIPTION
This PR introduces a new Cloud Function `network_connection_heartbeat` to verify network connectivity (heartbeat) to target projects (both Machine and Fleet projects) listed in the cluster intent source of truth.

### Key Features:
- **Network Heartbeat Function**: A new Cloud Function triggered by Cloud Scheduler every 10 minutes.
- **Targeted Checks**: Makes a simple read call to the Hardware Management API for each unique `machine_project_id`, and to the Edge Container API for each unique `fleet_project_id` to verify network reachability and permissions.
- **Custom Metrics**: Uploads heartbeat status (1 for success, 0 for failure) to Cloud Monitoring under `custom.googleapis.com/acp_network_heartbeat` with labels for `target_project_id`, `location`, and `target_type`.
- **Alerting Policy**: Adds a default Alerting Policy in `alerts.tf` that triggers if a project is unreachable for 25 minutes (tolerating one missed run).
- **Unit Tests**: Includes unit tests in `test_main.py` to verify the behavior of the new function.
### Manual Test via Deployment:

Metrics:
<img width="2932" height="1842" alt="image" src="https://github.com/user-attachments/assets/6bb3c436-db85-4172-a6b7-b27cb8d6f97c" />

Alert Policy:
<img width="3232" height="1550" alt="image" src="https://github.com/user-attachments/assets/9b56f7b7-9d47-40f8-b4bc-fc470fe0c6cd" />




