### PR TITLE
Increase platform healthcheck timeout from 1h to 2h

### DIFF
--- a/module/create-cluster.yaml
+++ b/module/create-cluster.yaml
@@ -497,15 +497,15 @@ steps:
       [[ ${count} -ge ${max_retries_for_healthcheck_creation} ]] && die "Health check resource not created after 20min"
 
       log_build_step "Waiting for platform healthchecks to pass"
-      if ! kubectl wait healthchecks.validator.gdc.gke.io/default --for condition=PlatformHealthy --timeout=1h; then
+      if ! kubectl wait healthchecks.validator.gdc.gke.io/default --for condition=PlatformHealthy --timeout=2h; then
         kubectl describe healthchecks.validator.gdc.gke.io/default
-        die "Platform is not healthy after 1h. Please review the failed platform health checks."
+        die "Platform is not healthy after 2h. Please review the failed platform health checks."
       fi
 
       # Calculate workload timeout by removing non-workload related buffer time from the over build timeout.
-      # ($TIMEOUT_IN_SECONDS) - (1h for platform health) - (1h for cluster health)
+      # ($TIMEOUT_IN_SECONDS) - (2h for platform health) - (1h for cluster health)
       #                       - (10m for extra buffer) - (30m for vm wait)
-      WORKLOAD_TIMEOUT="$(($TIMEOUT_IN_SECONDS-"9600"))"
+      WORKLOAD_TIMEOUT="$(($TIMEOUT_IN_SECONDS-"13200"))"
 
       log_build_step "Waiting for workload healthchecks to pass"
       if ! kubectl wait healthchecks.validator.gdc.gke.io/default --for condition=WorkloadsHealthy --timeout="${WORKLOAD_TIMEOUT}s"; then

--- a/module/variables.tf
+++ b/module/variables.tf
@@ -153,7 +153,7 @@ variable "hardware_management_api_endpoint_override" {
 
 variable "cluster_creation_timeout" {
   description = "Cloud Build timeout in seconds for cluster creation. This should account for time to create the cluster, configure core services (ConfigSync, Robin, VMRuntime, etc..), and time for any workload configuration needed before the healthchecks pass."
-  default     = "28800"
+  default     = "32400"
   type        = number
 }
 


### PR DESCRIPTION
Ref: b/506224078, this pull request extends the maximum permitted duration for platform healthchecks. The timing adjustments accommodate scenarios requiring prolonged platform verification without impacting subsequent workload processing phases.

**Key Changes:**
- **module/variables.tf:** Incremented the default value for `cluster_creation_timeout` from `28800`s (8h) to `32400`s (9h) to absorb the extended platform check timeframe.
- **module/create-cluster.yaml:**
  - Expanded the platform condition timeout in `kubectl wait` from `1h` to `2h`.
  - Updated error conditional assertions to output correct `2h` timing references.
  - Corrected the `WORKLOAD_TIMEOUT` deduction algorithm from `9600` to `13200` seconds to safely account for the extended durations.
