### PR TITLE
Implement structured failure signaling in create-cluster.yaml

### DIFF
--- a/module/create-cluster.yaml
+++ b/module/create-cluster.yaml
@@ -32,27 +32,6 @@ steps:
     fi
     HARDWARE_MANAGEMENT_API_VERSION="v1alpha"
 
-    function infer_grpc_code() {
-      local message="$1"
-      local code=2 # Default: UNKNOWN
-      
-      if [[ "$message" =~ "Missing" || "$message" =~ "Empty" || "$message" =~ "not set" ]]; then
-        code=3  # INVALID_ARGUMENT
-      elif [[ "$message" =~ "timeout" || "$message" =~ "timed out" || "$message" =~ "after 1h" || "$message" =~ "after 20min" ]]; then
-        code=4  # DEADLINE_EXCEEDED
-      elif [[ "$message" =~ "not found" ]]; then
-        code=5  # NOT_FOUND
-      elif [[ "$message" =~ "Secret Manager" || "$message" =~ "clone" ]]; then
-        code=7  # PERMISSION_DENIED
-      elif [[ "$message" =~ "only supported for" ]]; then
-        code=9  # FAILED_PRECONDITION
-      elif [[ "$message" =~ "signal the zone state" ]]; then
-        code=14 # UNAVAILABLE
-      fi
-      
-      echo "$code"
-    }
-
     function die() {
       if [[ "${INSIDE_DIE:-}" == "TRUE" ]]; then
         echo ">>> [CRITICAL] Recursive call to die detected. Exiting immediately."
@@ -60,14 +39,14 @@ steps:
       fi
       export INSIDE_DIE=TRUE
       set +x
+
       step="[Build: ${BUILD_ID}] $1"
       details=$2
       # Clean up logs by removing progress dots and ANSI color codes
       details=$(echo "$details" | sed -e 's/\.\{5,\}//g' -e 's/\x1b\[[0-9;]*[a-zA-Z]//g')
-      diag_output=$3
       
-      # Infer gRPC error code based on message
-      local code=$(infer_grpc_code "$1")
+      local code=${3:-2}
+      diag_output=$4
       
       # Capture last 30 lines of log for context
       local log_tail=$(tail -n 30 "$LOG_FILE" 2>/dev/null)
@@ -122,7 +101,7 @@ steps:
       set -x
 
       if [[ $curl_status -ne 0 ]]; then
-        die "Failed to signal the zone state" "$out"
+        die "Failed to signal the zone state" "$out" 14
       fi
 
       if [[ "$out" == "READY_FOR_CUSTOMER_FACTORY_TURNUP_CHECKS" || \
@@ -279,7 +258,7 @@ steps:
           echo ">>> [Zone Signal] [CRITICAL] Failed to send signal ${state_signal} to API while inside die." >&2
           exit 1
         else
-          die "Failed to signal the zone state" "$out"
+          die "Failed to signal the zone state" "$out" 14
         fi
       fi
       
@@ -308,7 +287,7 @@ steps:
           echo ">>> [Zone Signal] [CRITICAL] Signal operation timed out waiting for completion while inside die." >&2
           exit 1
         else
-          die "Signal operation timed out" "Operation $operation_id did not complete after $((max_retries_for_signal_completion * 5)) seconds."
+          die "Signal operation timed out" "Operation $operation_id did not complete after $((max_retries_for_signal_completion * 5)) seconds." 4
         fi
       else
         echo ">>> [Zone Signal] Operation completed successfully."
@@ -322,10 +301,10 @@ steps:
 
       output=$(echo "$input" | csvtool namedcol "$column" - | csvtool drop 1 - | tr -d '"')
 
-      [[ $? -ne 0 ]] && die "[CONFIG_VALIDATION_FAILED][cluster:${CLUSTER_NAME:-unknown}] missing column header: $column" "Input data:\n$input" >&2
+      [[ $? -ne 0 ]] && die "[CONFIG_VALIDATION_FAILED][cluster:${CLUSTER_NAME:-unknown}] missing column header: $column" "Input data:\n$input" 3 >&2
 
       if [ -z "$output" ]; then
-        die "[CONFIG_VALIDATION_FAILED][cluster:${CLUSTER_NAME:-unknown}] empty cell value: $column" "Input data:\n$input" >&2
+        die "[CONFIG_VALIDATION_FAILED][cluster:${CLUSTER_NAME:-unknown}] empty cell value: $column" "Input data:\n$input" 3 >&2
       fi
 
       echo "$output"
@@ -360,12 +339,12 @@ steps:
       local fleet_config_path="repo/$FLEET_CONFIG_PATH"
       
       if [[ ! -f "$fleet_config_path" ]]; then
-         die "[CONFIG_VALIDATION_FAILED][cluster:${CLUSTER_NAME:-unknown}] Fleet config file not found at $fleet_config_path but required for fallback" "Please check if the git repository contains the file at path: $FLEET_CONFIG_PATH" >&2
+         die "[CONFIG_VALIDATION_FAILED][cluster:${CLUSTER_NAME:-unknown}] Fleet config file not found at $fleet_config_path but required for fallback" "Please check if the git repository contains the file at path: $FLEET_CONFIG_PATH" 5 >&2
       fi
       local row=$(awk -F , "\$1 == \"$project_id\" || \$1 == \"\\\"$project_id\\\"\"" "$fleet_config_path")
       
       if [[ -z "$row" ]]; then
-         die "[CONFIG_VALIDATION_FAILED][cluster:${CLUSTER_NAME:-unknown}] Project $project_id not found in $fleet_config_path" "File contents of $fleet_config_path:\n$(cat "$fleet_config_path" 2>/dev/null)" >&2
+         die "[CONFIG_VALIDATION_FAILED][cluster:${CLUSTER_NAME:-unknown}] Project $project_id not found in $fleet_config_path" "File contents of $fleet_config_path:\n$(cat "$fleet_config_path" 2>/dev/null)" 5 >&2
       fi
       
       local header=$(head -1 "$fleet_config_path")
@@ -436,18 +415,18 @@ steps:
     # Preemptively install required packages silently to maintain clean visual layouts
     apt-get update -qq && apt-get install -y -qq gettext-base csvtool jq > /dev/null
 
-    [[ -z "${STORE_ID}" ]] && die "[CONFIG_VALIDATION_FAILED] STORE_ID not set. Please ensure store_id is provided in the trigger."
+    [[ -z "${STORE_ID}" ]] && die "[CONFIG_VALIDATION_FAILED] STORE_ID not set. Please ensure store_id is provided in the trigger." "" 3
 
     NODE_LOCATION=${ZONE}
-    [[ -z "$NODE_LOCATION" ]] && die "[CONFIG_VALIDATION_FAILED] ZONE not set. Please ensure zone is provided in the trigger."
+    [[ -z "$NODE_LOCATION" ]] && die "[CONFIG_VALIDATION_FAILED] ZONE not set. Please ensure zone is provided in the trigger." "" 3
 
-    TOKEN=$(gcloud secrets versions access latest --secret=$GIT_SECRET_ID --project $GIT_SECRETS_PROJECT_ID) || die "[CUSTOMER_ERROR][store:${STORE_ID}] Failed to retrieve git token from Secret Manager" "Secret name: $GIT_SECRET_ID, Project ID: $GIT_SECRETS_PROJECT_ID"
-    git clone -b $SOURCE_OF_TRUTH_BRANCH https://oauth2:$TOKEN@$SOURCE_OF_TRUTH_REPO repo || die "[CUSTOMER_ERROR][store:${STORE_ID}] Failed to clone source of truth repository" "Repo: $SOURCE_OF_TRUTH_REPO, Branch: $SOURCE_OF_TRUTH_BRANCH"
-    cp repo/$SOURCE_OF_TRUTH_PATH ./cluster-intent-registry.csv || die "[CUSTOMER_ERROR][store:${STORE_ID}] Failed to copy cluster intent file" "Source of truth path: $SOURCE_OF_TRUTH_PATH"
+    TOKEN=$(gcloud secrets versions access latest --secret=$GIT_SECRET_ID --project $GIT_SECRETS_PROJECT_ID) || die "[CUSTOMER_ERROR][store:${STORE_ID}] Failed to retrieve git token from Secret Manager" "Secret name: $GIT_SECRET_ID, Project ID: $GIT_SECRETS_PROJECT_ID" 7
+    git clone -b $SOURCE_OF_TRUTH_BRANCH https://oauth2:$TOKEN@$SOURCE_OF_TRUTH_REPO repo || die "[CUSTOMER_ERROR][store:${STORE_ID}] Failed to clone source of truth repository" "Repo: $SOURCE_OF_TRUTH_REPO, Branch: $SOURCE_OF_TRUTH_BRANCH" 7
+    cp repo/$SOURCE_OF_TRUTH_PATH ./cluster-intent-registry.csv || die "[CUSTOMER_ERROR][store:${STORE_ID}] Failed to copy cluster intent file" "Source of truth path: $SOURCE_OF_TRUTH_PATH" 5
 
     export CLUSTER_INTENT_ROW=$(awk -F , "\$1 == \"$STORE_ID\" || \$1 == \"\\\"$STORE_ID\\\"\"" cluster-intent-registry.csv)
     echo ">>> [SoT Parse] $CLUSTER_INTENT_ROW"
-    [[ -z "$CLUSTER_INTENT_ROW" ]] && die "[CONFIG_VALIDATION_FAILED] Cluster intent not found for store: $STORE_ID" "Store ID: $STORE_ID, Intent CSV file contents:\n$(cat cluster-intent-registry.csv 2>/dev/null)"
+    [[ -z "$CLUSTER_INTENT_ROW" ]] && die "[CONFIG_VALIDATION_FAILED] Cluster intent not found for store: $STORE_ID" "Store ID: $STORE_ID, Intent CSV file contents:\n$(cat cluster-intent-registry.csv 2>/dev/null)" 5
     export CLUSTER_INTENT_HEADER=$(head -1 cluster-intent-registry.csv)
     export CLUSTER_INTENT="$CLUSTER_INTENT_HEADER"$'\n'"$CLUSTER_INTENT_ROW"
 
@@ -540,7 +519,7 @@ steps:
           # Update command to use alpha until this flag is GA'ed
           GCLOUD_CMD="gcloud alpha"
         else
-          die "[INVALID_ROBIN_REQUEST][cluster:${CLUSTER_NAME:-unknown}] Invalid Robin CNS request: Robin CNS requires version 1.12.0+ but got ${CLUSTER_VERSION}"
+          die "[INVALID_ROBIN_REQUEST][cluster:${CLUSTER_NAME:-unknown}] Invalid Robin CNS request" "Robin CNS requires version 1.12.0+ but got ${CLUSTER_VERSION}" 9
         fi
       fi
 
@@ -603,7 +582,7 @@ steps:
           --zone $NODE_LOCATION --project $MACHINE_PROJECT_ID \
           --filter="VLANID=$vlan" --format="json" 2>&1)
 
-      [[ $? -ne 0 ]] && die "Unable to query for subnets" "$EXISTING_VLAN"
+      [[ $? -ne 0 ]] && die "Unable to query for subnets" "$EXISTING_VLAN" 7
 
       if [ "$EXISTING_VLAN" = "[]" ]; then
         out=$(gcloud edge-cloud networking subnets create "network-$vlan" \
@@ -628,7 +607,7 @@ steps:
     fi
 
     export KUBECONFIG="$(pwd)/gateway-kubeconfig"
-    out=$(gcloud container fleet memberships get-credentials $CLUSTER_NAME --project $FLEET_PROJECT_ID 2>&1) || die "Failed to get cluster credentials" "$out"
+    out=$(gcloud container fleet memberships get-credentials $CLUSTER_NAME --project $FLEET_PROJECT_ID 2>&1) || die "Failed to get cluster credentials" "$out" 7
 
     out=$(gcloud storage cp gs://$CLUSTER_INTENT_BUCKET/apply-spec.yaml.template . 2>&1) || die "Failed to copy apply-spec template from GCS" "$out"
 
@@ -650,8 +629,8 @@ steps:
     rcs=("${PIPESTATUS[@]}")
     if [[ ${rcs[0]} -ne 0 || ${rcs[1]} -ne 0 ]]; then
       diag=$(kubectl cluster-info 2>/dev/null || echo "[DIAGNOSTIC_FAILED] Cluster unreachable")
-      [[ ${rcs[0]} -ne 0 ]] && die "Failed to create namespace" "Command failed: kubectl create ns config-management-system --dry-run=client -o yaml (Exit code: ${rcs[0]})" "$diag"
-      [[ ${rcs[1]} -ne 0 ]] && die "Failed to apply namespace" "Command failed: kubectl apply -f - (Exit code: ${rcs[1]})" "$diag"
+      [[ ${rcs[0]} -ne 0 ]] && die "Failed to create namespace" "Command failed: kubectl create ns config-management-system --dry-run=client -o yaml (Exit code: ${rcs[0]})" 2 "$diag"
+      [[ ${rcs[1]} -ne 0 ]] && die "Failed to apply namespace" "Command failed: kubectl apply -f - (Exit code: ${rcs[1]})" 2 "$diag"
     fi
 
     set +x
@@ -662,8 +641,8 @@ steps:
     set -x
     if [[ ${rcs[0]} -ne 0 || ${rcs[1]} -ne 0 ]]; then
       diag=$(kubectl cluster-info 2>/dev/null || echo "Cluster unreachable")
-      [[ ${rcs[0]} -ne 0 ]] && die "Failed to create secret" "Command failed: kubectl create secret generic git-creds ... (Exit code: ${rcs[0]})" "$diag"
-      [[ ${rcs[1]} -ne 0 ]] && die "Failed to apply secret" "Command failed: kubectl apply -f - (Exit code: ${rcs[1]})" "$diag"
+      [[ ${rcs[0]} -ne 0 ]] && die "Failed to create secret" "Command failed: kubectl create secret generic git-creds ... (Exit code: ${rcs[0]})" 2 "$diag"
+      [[ ${rcs[1]} -ne 0 ]] && die "Failed to apply secret" "Command failed: kubectl apply -f - (Exit code: ${rcs[1]})" 2 "$diag"
     fi
 
     out=$(gcloud beta container fleet config-management apply --membership=$CLUSTER_NAME \
@@ -672,7 +651,7 @@ steps:
     set -e
     if [[ $rc -ne 0 ]]; then
       diag=$(kubectl get rootsync -n config-management-system -o yaml 2>/dev/null || echo "[DIAGNOSTIC_FAILED] Failed to get RootSync status")
-      die "Config Sync apply failed" "$out" "$diag"
+      die "Config Sync apply failed" "$out" 2 "$diag"
     fi
 
     out=$(gcloud storage cp gs://$CLUSTER_INTENT_BUCKET/fleet-packages-rbac.yaml.template . 2>&1) || die "Failed to copy fleet packages RBAC template" "$out"
@@ -682,7 +661,7 @@ steps:
 
     out=$(kubectl apply -f fleet-packages-rbac.yaml 2>&1) || {
       diag=$(kubectl cluster-info 2>/dev/null || echo "[DIAGNOSTIC_FAILED] Cluster unreachable")
-      die "Failed to apply fleet packages RBAC" "$out" "$diag"
+      die "Failed to apply fleet packages RBAC" "$out" 2 "$diag"
     }
 
     # Apply old Group RBAC steps if cluster version is less than 1.10.0
@@ -692,7 +671,7 @@ steps:
       kubectl patch clientconfig default -n kube-public --type=merge -p '{"spec":{"authentication":[{"google":{"audiences":["//'${GKEHUB_API_ENDPOINT}'/projects/'${FLEET_PROJECT_NUMBER}'/locations/global/memberships/'${CLUSTER_NAME}'"]},"name":"google-authentication-method"}]}}' || {
         rc=$?
         diag=$(kubectl get clientconfig default -n kube-public -o yaml 2>/dev/null || echo "[DIAGNOSTIC_FAILED] Failed to get clientconfig status")
-        die "Failed to patch clientconfig for Group RBAC" "Exit code: $rc" "$diag"
+        die "Failed to patch clientconfig for Group RBAC" "Exit code: $rc" 2 "$diag"
       }
       log_build_step "Group RBAC applied"
     else
@@ -713,13 +692,13 @@ steps:
       done
       if [[ ${count} -ge ${max_retries_for_healthcheck_creation} ]]; then
         diag=$(kubectl get crd healthchecks.validator.gdc.gke.io -o yaml 2>/dev/null || echo "[DIAGNOSTIC_FAILED] CRD not found")
-        die "Health check resource not created after 20min" "Timeout waiting for resource creation" "$diag"
+        die "Health check resource not created after 20min" "Timeout waiting for resource creation" 4 "$diag"
       fi
 
       log_build_step "Waiting for platform healthchecks to pass"
       if ! kubectl wait healthchecks.validator.gdc.gke.io/default --for condition=PlatformHealthy --timeout=1h; then
         diag=$(kubectl get healthchecks.validator.gdc.gke.io/default -o yaml 2>/dev/null || echo "Failed to get healthcheck status")
-        die "Platform is not healthy after 1h" "Timeout waiting for condition=PlatformHealthy" "$diag"
+        die "Platform is not healthy after 1h" "Timeout waiting for condition=PlatformHealthy" 4 "$diag"
       fi
 
       # Calculate workload timeout by removing non-workload related buffer time from the over build timeout.
@@ -730,7 +709,7 @@ steps:
       log_build_step "Waiting for workload healthchecks to pass"
       if ! kubectl wait healthchecks.validator.gdc.gke.io/default --for condition=WorkloadsHealthy --timeout="${WORKLOAD_TIMEOUT}s"; then
         diag=$(kubectl get healthchecks.validator.gdc.gke.io/default -o yaml 2>/dev/null || echo "Failed to get healthcheck status")
-        die "[CUSTOMER_ERROR] Workloads are not healthy after ${WORKLOAD_TIMEOUT}s" "Timeout waiting for condition=WorkloadsHealthy" "$diag"
+        die "[CUSTOMER_ERROR] Workloads are not healthy after ${WORKLOAD_TIMEOUT}s" "Timeout waiting for condition=WorkloadsHealthy" 4 "$diag"
       fi
     fi
     
@@ -753,7 +732,7 @@ steps:
     done
     if [[ $fail -ne 0 ]]; then
       diag=$(kubectl get vmi -n vm-workloads -o yaml 2>/dev/null || echo "[DIAGNOSTIC_FAILED] Failed to get VMI status")
-      die "Unsuccessful VM termination sequence" "Failed to stop all VMs" "$diag"
+      die "Unsuccessful VM termination sequence" "Failed to stop all VMs" 2 "$diag"
     fi
 
     set +eE

--- a/module/create-cluster.yaml
+++ b/module/create-cluster.yaml
@@ -22,29 +22,64 @@ steps:
     set +x
     set -o pipefail
 
+    # Capture all output to a file for log_tail in case of failure
+    LOG_FILE="/tmp/acp_execution_create_cluster_${BUILD_ID}.log"
+    exec > >(tee -a "$LOG_FILE") 2>&1
+
     HARDWARE_MANAGEMENT_API_ENDPOINT="https://gdchardwaremanagement.googleapis.com"
     if [[ -n "${HARDWARE_MANAGEMENT_API_ENDPOINT_OVERRIDE}" ]]; then
       HARDWARE_MANAGEMENT_API_ENDPOINT=${HARDWARE_MANAGEMENT_API_ENDPOINT_OVERRIDE}
     fi
     HARDWARE_MANAGEMENT_API_VERSION="v1alpha"
 
+    function infer_grpc_code() {
+      local message="$1"
+      local code=2 # Default: UNKNOWN
+      
+      if [[ "$message" =~ "Missing" || "$message" =~ "Empty" || "$message" =~ "not set" ]]; then
+        code=3  # INVALID_ARGUMENT
+      elif [[ "$message" =~ "timeout" || "$message" =~ "timed out" || "$message" =~ "after 1h" || "$message" =~ "after 20min" ]]; then
+        code=4  # DEADLINE_EXCEEDED
+      elif [[ "$message" =~ "not found" ]]; then
+        code=5  # NOT_FOUND
+      elif [[ "$message" =~ "Secret Manager" || "$message" =~ "clone" ]]; then
+        code=7  # PERMISSION_DENIED
+      elif [[ "$message" =~ "only supported for" ]]; then
+        code=9  # FAILED_PRECONDITION
+      elif [[ "$message" =~ "signal the zone state" ]]; then
+        code=14 # UNAVAILABLE
+      fi
+      
+      echo "$code"
+    }
+
     function die() {
       set +x
       step="[Build: ${BUILD_ID}] $1"
       details=$2
+      # Clean up logs by removing progress dots and ANSI color codes
+      details=$(echo "$details" | sed -e 's/\.\{5,\}//g' -e 's/\x1b\[[0-9;]*[a-zA-Z]//g')
+      diag_output=$3
+      
+      # Infer gRPC error code based on message
+      local code=$(infer_grpc_code "$1")
+      
+      # Capture last 30 lines of log for context
+      local log_tail=$(tail -n 30 "$LOG_FILE" 2>/dev/null)
       echo ">>> [ERROR] $step"
       echo ">>> [ERROR] Details: $details"
+      [[ -n "$diag_output" ]] && echo ">>> [ERROR] Diagnostic Output: $diag_output"
       echo ">>> [ERROR] [Build: ${BUILD_ID}] Cluster Creation Failed for $CLUSTER_NAME: $1"
 
       if [[ "$MAX_RETRIES" -eq 0 ]]; then
         echo ">>> [ERROR] Marking zone as failed"
-        zone_signal "$ZONE_ID" FACTORY_TURNUP_CHECKS_FAILED "$step" "$details"
+        zone_signal "$ZONE_ID" FACTORY_TURNUP_CHECKS_FAILED "$step" "$details" "$diag_output" "$log_tail" "$code"
       else
         # Instead of querying build history with gcloud (which is slow and was counting builds from previous lifecycles),
         # we directly use the TRY_COUNT passed from Zone Watcher to check if we exceeded MAX_RETRIES.
         if [[ "$TRY_COUNT" -gt "$MAX_RETRIES" ]]; then
           echo ">>> [ERROR] Current try count $TRY_COUNT has exhausted max retries $MAX_RETRIES. Marking zone as failed"
-          zone_signal "$ZONE_ID" FACTORY_TURNUP_CHECKS_FAILED "$step" "$details"
+          zone_signal "$ZONE_ID" FACTORY_TURNUP_CHECKS_FAILED "$step" "$details" "$diag_output" "$log_tail" "$code"
         else
           echo ">>> [ERROR] Current try count $TRY_COUNT is <= max retries $MAX_RETRIES. Skipping failure signal to allow next retry."
         fi
@@ -96,11 +131,43 @@ steps:
       fi
     }
 
+    function get_cluster_intent_json() {
+      cat <<EOF | jq .
+      {
+        "store_id": "${STORE_ID:-}",
+        "machine_project_id": "${MACHINE_PROJECT_ID:-}",
+        "fleet_project_id": "${FLEET_PROJECT_ID:-}",
+        "cluster_name": "${CLUSTER_NAME:-}",
+        "location": "${LOCATION:-}",
+        "node_count": "${NODE_COUNT:-}",
+        "cluster_ipv4_cidr": "${CLUSTER_IPV4_CIDR:-}",
+        "services_ipv4_cidr": "${SERVICES_IPV4_CIDR:-}",
+        "external_load_balancer_ipv4_address_pools": "${EXTERNAL_LOAD_BALANCER_IPV4_ADDRESS_POOLS:-}",
+        "sync_repo": "${SYNC_REPO:-}",
+        "sync_branch": "${SYNC_BRANCH:-}",
+        "sync_dir": "${SYNC_DIR:-}",
+        "secrets_project_id": "${SECRETS_PROJECT_ID:-}",
+        "git_token_secrets_manager_name": "${GIT_TOKEN_SECRETS_MANAGER_NAME:-}",
+        "cluster_version": "${CLUSTER_VERSION:-}",
+        "maintenance_window_start": "${MAINTENANCE_WINDOW_START:-}",
+        "maintenance_window_end": "${MAINTENANCE_WINDOW_END:-}",
+        "maintenance_window_recurrence": "${MAINTENANCE_WINDOW_RECURRENCE:-}",
+        "subnet_vlans": "${SUBNET_VLANS:-}",
+        "enable_robin_cns": "${ENABLE_ROBIN_CNS:-}",
+        "zone_name": "${ZONE_NAME_FROM_SOT:-}",
+        "labels": "${LABELS:-}"
+      }
+    EOF
+    }
+
     function zone_signal() {
       zone_store_path=$1
       state_signal=$2
       step=$3
       details=$4
+      diag_output=$5
+      log_tail=$6
+      local code=$7
 
       [[ -z "${zone_store_path}" ]] && { echo ">>> [Zone Signal] zone_store_path not provided"; return ; }
 
@@ -113,6 +180,8 @@ steps:
         echo ">>> [Zone Signal] Suppressing message details (OPT_IN_BUILD_MESSAGES != TRUE)"
         step=""
         details=""
+        diag_output=""
+        log_tail=""
       fi
 
       SIGNAL_URI="${HARDWARE_MANAGEMENT_API_ENDPOINT}/${HARDWARE_MANAGEMENT_API_VERSION}/${zone_store_path}:signal"
@@ -123,7 +192,50 @@ steps:
       if [[ $state_signal == "FACTORY_TURNUP_CHECKS_STARTED" ]]; then
         state_signal_payload=$(jq -n --arg ss "$state_signal" --arg st "$step" '{"state_signal": $ss, "step": $st}')
       elif [[ $state_signal == "FACTORY_TURNUP_CHECKS_FAILED" ]]; then
-        state_signal_payload=$(jq -n --arg ss "$state_signal" --arg st "$step" --arg dt "$details" '{"state_signal": $ss, "step": $st, "details": $dt}')
+        # Construct cluster_intent JSON object using the dedicated function
+        local cluster_intent_json=$(get_cluster_intent_json)
+
+        # Construct error details (ErrorInfo) safely using jq
+        local error_details=$(jq -n \
+          --arg reason "PROVISIONING_FAILED" \
+          --arg domain "acp.gdc.gke.io" \
+          --arg raw_error "$details" \
+          --arg diag "$diag_output" \
+          --arg tail "$log_tail" \
+          '[{
+            "@type": "type.googleapis.com/google.rpc.ErrorInfo",
+            "reason": $reason,
+            "domain": $domain,
+            "metadata": {
+              "raw_error": $raw_error,
+              "diagnostic_output": $diag,
+              "log_tail": $tail
+            }
+          }]')
+
+        # Construct full payload matching the new Proto contract
+        state_signal_payload=$(jq -n \
+          --arg signal "$state_signal" \
+          --arg step "$step" \
+          --arg build_id "${BUILD_ID:-}" \
+          --arg cluster_version "${CLUSTER_VERSION:-}" \
+          --argjson code "$code" \
+          --argjson intent "$cluster_intent_json" \
+          --argjson err_details "$error_details" \
+          '{
+            state_signal: $signal,
+            step: $step,
+            provisioning_context: {
+              build_id: $build_id,
+              cluster_version: $cluster_version,
+              cluster_intent: $intent
+            },
+            error: {
+              code: $code,
+              message: $step,
+              details: $err_details
+            }
+          }')
       else
         state_signal_payload=$(jq -n --arg ss "$state_signal" '{"state_signal": $ss}')
       fi
@@ -421,7 +533,7 @@ steps:
         $GCLOUD_CMD "${CMD_ARGS[@]}" 2>&1 | tee /dev/fd/5
       )
 
-      [[ $? -ne 0 ]] && die "Failure from gcloud edge-cloud container clusters" "$out"
+      [[ $? -ne 0 ]] && die "Failure from gcloud edge-cloud container clusters create command" "$out"
 
 
     fi
@@ -440,14 +552,14 @@ steps:
           --location=$LOCATION \
           --maintenance-window-start=$MAINTENANCE_WINDOW_START \
           --maintenance-window-end=$MAINTENANCE_WINDOW_END \
-          --maintenance-window-recurrence=$MAINTENANCE_WINDOW_RECURRENCE)
+          --maintenance-window-recurrence=$MAINTENANCE_WINDOW_RECURRENCE 2>&1)
       [[ $? -ne 0 ]] && die "Maintenance window update failed" "$out"
     fi
 
     log_build_step "Initializing zone network"
     out=$(gcloud edge-cloud networking zones init $NODE_LOCATION \
       --project=$MACHINE_PROJECT_ID \
-      --location=$LOCATION)
+      --location=$LOCATION 2>&1)
 
     [[ $? -ne 0 ]] && die "Zone network failed to initialize" "$out"
 
@@ -455,9 +567,9 @@ steps:
     for vlan in $(echo $SUBNET_VLANS | csvtool transpose -); do
       EXISTING_VLAN=$(gcloud edge-cloud networking subnets list --location $LOCATION \
           --zone $NODE_LOCATION --project $MACHINE_PROJECT_ID \
-          --filter="VLANID=$vlan" --format="json")
+          --filter="VLANID=$vlan" --format="json" 2>&1)
 
-      [[ $? -ne 0 ]] && die "Unable to query for subnets"
+      [[ $? -ne 0 ]] && die "Unable to query for subnets" "$EXISTING_VLAN"
 
       if [ "$EXISTING_VLAN" = "[]" ]; then
         out=$(gcloud edge-cloud networking subnets create "network-$vlan" \
@@ -465,7 +577,7 @@ steps:
             --network=default \
             --location=$LOCATION \
             --zone=$NODE_LOCATION \
-            --project $MACHINE_PROJECT_ID)
+            --project $MACHINE_PROJECT_ID 2>&1)
         [[ $? -ne 0 ]] && die "Subnet creation failed" "$out"
       else
         echo ">>> [Cluster Create] VLAN $vlan already exists"
@@ -478,19 +590,19 @@ steps:
     set -x
     if [ -n "$LABELS" ]; then
       log_build_step "Adding fleet membership labels"
-      gcloud container fleet memberships update $CLUSTER_NAME --clear-labels --update-labels $LABELS
+      out=$(gcloud container fleet memberships update $CLUSTER_NAME --clear-labels --update-labels $LABELS 2>&1) || die "Failed to update fleet membership labels" "$out"
     fi
 
     export KUBECONFIG="$(pwd)/gateway-kubeconfig"
-    gcloud container fleet memberships get-credentials $CLUSTER_NAME --project $FLEET_PROJECT_ID
+    out=$(gcloud container fleet memberships get-credentials $CLUSTER_NAME --project $FLEET_PROJECT_ID 2>&1) || die "Failed to get cluster credentials" "$out"
 
-    gcloud storage cp gs://$CLUSTER_INTENT_BUCKET/apply-spec.yaml.template .
+    out=$(gcloud storage cp gs://$CLUSTER_INTENT_BUCKET/apply-spec.yaml.template . 2>&1) || die "Failed to copy apply-spec template from GCS" "$out"
 
     if [[ -n "$CS_VERSION" ]]; then
       export CS_VERSION_YAML="version: $CS_VERSION"
     fi
 
-    envsubst < apply-spec.yaml.template > apply-spec.yaml
+    out=$(envsubst < apply-spec.yaml.template > apply-spec.yaml 2>&1) || die "Failed to substitute environment variables in template" "$out"
     set +x
     log_build_step "Configuring configsync"
     gcloud secrets versions access latest --secret=$GIT_TOKEN_SECRETS_MANAGER_NAME \
@@ -502,8 +614,11 @@ steps:
 
     kubectl create ns config-management-system --dry-run=client -o yaml | kubectl apply -f -
     rcs=("${PIPESTATUS[@]}")
-    [[ ${rcs[0]} -ne 0 ]] && die "Failed to create namespace" "Command failed: kubectl create ns config-management-system --dry-run=client -o yaml (Exit code: ${rcs[0]})"
-    [[ ${rcs[1]} -ne 0 ]] && die "Failed to apply namespace" "Command failed: kubectl apply -f - (Exit code: ${rcs[1]})"
+    if [[ ${rcs[0]} -ne 0 || ${rcs[1]} -ne 0 ]]; then
+      diag=$(kubectl cluster-info 2>/dev/null || echo "[DIAGNOSTIC_FAILED] Cluster unreachable")
+      [[ ${rcs[0]} -ne 0 ]] && die "Failed to create namespace" "Command failed: kubectl create ns config-management-system --dry-run=client -o yaml (Exit code: ${rcs[0]})" "$diag"
+      [[ ${rcs[1]} -ne 0 ]] && die "Failed to apply namespace" "Command failed: kubectl apply -f - (Exit code: ${rcs[1]})" "$diag"
+    fi
 
     set +x
     kubectl create secret generic git-creds --namespace="config-management-system" \
@@ -511,27 +626,40 @@ steps:
         --dry-run=client -o yaml | kubectl apply -f -
     rcs=("${PIPESTATUS[@]}")
     set -x
-    [[ ${rcs[0]} -ne 0 ]] && die "Failed to create secret" "Command failed: kubectl create secret generic git-creds ... (Exit code: ${rcs[0]})"
-    [[ ${rcs[1]} -ne 0 ]] && die "Failed to apply secret" "Command failed: kubectl apply -f - (Exit code: ${rcs[1]})"
+    if [[ ${rcs[0]} -ne 0 || ${rcs[1]} -ne 0 ]]; then
+      diag=$(kubectl cluster-info 2>/dev/null || echo "Cluster unreachable")
+      [[ ${rcs[0]} -ne 0 ]] && die "Failed to create secret" "Command failed: kubectl create secret generic git-creds ... (Exit code: ${rcs[0]})" "$diag"
+      [[ ${rcs[1]} -ne 0 ]] && die "Failed to apply secret" "Command failed: kubectl apply -f - (Exit code: ${rcs[1]})" "$diag"
+    fi
 
-    set -e # Restore errexit
-    trap 'die "Error configuring cluster" "Command that failed: $BASH_COMMAND"' ERR # Restore trap
+    out=$(gcloud beta container fleet config-management apply --membership=$CLUSTER_NAME \
+        --config=./apply-spec.yaml --project $FLEET_PROJECT_ID 2>&1)
+    rc=$?
+    set -e
+    if [[ $rc -ne 0 ]]; then
+      diag=$(kubectl get rootsync -n config-management-system -o yaml 2>/dev/null || echo "[DIAGNOSTIC_FAILED] Failed to get RootSync status")
+      die "Config Sync apply failed" "$out" "$diag"
+    fi
 
-    gcloud beta container fleet config-management apply --membership=$CLUSTER_NAME \
-        --config=./apply-spec.yaml --project $FLEET_PROJECT_ID
-
-    gcloud storage cp gs://$CLUSTER_INTENT_BUCKET/fleet-packages-rbac.yaml.template .
-    export PROJECT_NUMBER=$(gcloud projects describe $FLEET_PROJECT_ID --format="value(projectNumber)")
+    out=$(gcloud storage cp gs://$CLUSTER_INTENT_BUCKET/fleet-packages-rbac.yaml.template . 2>&1) || die "Failed to copy fleet packages RBAC template" "$out"
+    export PROJECT_NUMBER=$(gcloud projects describe $FLEET_PROJECT_ID --format="value(projectNumber)" 2>&1) || die "Failed to describe project" "$PROJECT_NUMBER"
     
-    envsubst < fleet-packages-rbac.yaml.template > fleet-packages-rbac.yaml
+    out=$(envsubst < fleet-packages-rbac.yaml.template > fleet-packages-rbac.yaml 2>&1) || die "Failed to substitute environment variables in template" "$out"
 
-    kubectl apply -f fleet-packages-rbac.yaml
+    out=$(kubectl apply -f fleet-packages-rbac.yaml 2>&1) || {
+      diag=$(kubectl cluster-info 2>/dev/null || echo "[DIAGNOSTIC_FAILED] Cluster unreachable")
+      die "Failed to apply fleet packages RBAC" "$out" "$diag"
+    }
 
     # Apply old Group RBAC steps if cluster version is less than 1.10.0
     if [[ "${SKIP_IDENTITY_SERVICE}" == "FALSE" ]] &&  ! gdc_version_evaluate "${CLUSTER_VERSION}" "1.10.0"; then
       log_build_step "Configuring manual Group RBAC"
-      FLEET_PROJECT_NUMBER=$(gcloud projects describe $FLEET_PROJECT_ID --format='value(projectNumber)')
-      kubectl patch clientconfig default -n kube-public --type=merge -p '{"spec":{"authentication":[{"google":{"audiences":["//'${GKEHUB_API_ENDPOINT}'/projects/'${FLEET_PROJECT_NUMBER}'/locations/global/memberships/'${CLUSTER_NAME}'"]},"name":"google-authentication-method"}]}}'
+      FLEET_PROJECT_NUMBER=$(gcloud projects describe $FLEET_PROJECT_ID --format='value(projectNumber)' 2>&1) || die "Failed to describe project for Group RBAC" "$FLEET_PROJECT_NUMBER"
+      kubectl patch clientconfig default -n kube-public --type=merge -p '{"spec":{"authentication":[{"google":{"audiences":["//'${GKEHUB_API_ENDPOINT}'/projects/'${FLEET_PROJECT_NUMBER}'/locations/global/memberships/'${CLUSTER_NAME}'"]},"name":"google-authentication-method"}]}}' || {
+        rc=$?
+        diag=$(kubectl get clientconfig default -n kube-public -o yaml 2>/dev/null || echo "[DIAGNOSTIC_FAILED] Failed to get clientconfig status")
+        die "Failed to patch clientconfig for Group RBAC" "Exit code: $rc" "$diag"
+      }
       log_build_step "Group RBAC applied"
     else
       log_build_step "Skipping manual Group RBAC setup"
@@ -546,16 +674,18 @@ steps:
       log_build_step "Waiting for health check resource to be created"
       while [[ ${count} -lt ${max_retries_for_healthcheck_creation} ]]; do
         kubectl get healthchecks.validator.gdc.gke.io/default >/dev/null 2>&1 && break
-        echo -n .
         sleep 5
         ((count++))
       done
-      [[ ${count} -ge ${max_retries_for_healthcheck_creation} ]] && die "Health check resource not created after 20min"
+      if [[ ${count} -ge ${max_retries_for_healthcheck_creation} ]]; then
+        diag=$(kubectl get crd healthchecks.validator.gdc.gke.io -o yaml 2>/dev/null || echo "[DIAGNOSTIC_FAILED] CRD not found")
+        die "Health check resource not created after 20min" "Timeout waiting for resource creation" "$diag"
+      fi
 
       log_build_step "Waiting for platform healthchecks to pass"
       if ! kubectl wait healthchecks.validator.gdc.gke.io/default --for condition=PlatformHealthy --timeout=1h; then
-        kubectl describe healthchecks.validator.gdc.gke.io/default
-        die "Platform is not healthy after 1h. Please review the failed platform health checks."
+        diag=$(kubectl get healthchecks.validator.gdc.gke.io/default -o yaml 2>/dev/null || echo "Failed to get healthcheck status")
+        die "Platform is not healthy after 1h" "Timeout waiting for condition=PlatformHealthy" "$diag"
       fi
 
       # Calculate workload timeout by removing non-workload related buffer time from the over build timeout.
@@ -565,8 +695,8 @@ steps:
 
       log_build_step "Waiting for workload healthchecks to pass"
       if ! kubectl wait healthchecks.validator.gdc.gke.io/default --for condition=WorkloadsHealthy --timeout="${WORKLOAD_TIMEOUT}s"; then
-        kubectl describe healthchecks.validator.gdc.gke.io/default
-        die "[CUSTOMER_ERROR] Workloads are not healthy after ${WORKLOAD_TIMEOUT}s. Please review the failed workload health checks."
+        diag=$(kubectl get healthchecks.validator.gdc.gke.io/default -o yaml 2>/dev/null || echo "Failed to get healthcheck status")
+        die "[CUSTOMER_ERROR] Workloads are not healthy after ${WORKLOAD_TIMEOUT}s" "Timeout waiting for condition=WorkloadsHealthy" "$diag"
       fi
     fi
     
@@ -581,10 +711,16 @@ steps:
     sleep 30m
 
     log_build_step "Shutting down running VMs"
-    for vm in $(kubectl get vmi -n vm-workloads --no-headers | awk '{print $1}'); do
+    vms=$(kubectl get vmi -n vm-workloads --no-headers | awk '{print $1}')
+    fail=0
+    for vm in $vms; do
       echo ">>> [Cluster Create] Shutting down $vm"
-      ./virtctl stop -n vm-workloads $vm
+      ./virtctl stop -n vm-workloads $vm || fail=1
     done
+    if [[ $fail -ne 0 ]]; then
+      diag=$(kubectl get vmi -n vm-workloads -o yaml 2>/dev/null || echo "[DIAGNOSTIC_FAILED] Failed to get VMI status")
+      die "Unsuccessful VM termination sequence" "Failed to stop all VMs" "$diag"
+    fi
 
     set +eE
     trap - ERR

--- a/module/create-cluster.yaml
+++ b/module/create-cluster.yaml
@@ -54,6 +54,11 @@ steps:
     }
 
     function die() {
+      if [[ "${INSIDE_DIE:-}" == "TRUE" ]]; then
+        echo ">>> [CRITICAL] Recursive call to die detected. Exiting immediately."
+        exit 1
+      fi
+      export INSIDE_DIE=TRUE
       set +x
       step="[Build: ${BUILD_ID}] $1"
       details=$2
@@ -117,7 +122,7 @@ steps:
       set -x
 
       if [[ $curl_status -ne 0 ]]; then
-        die "Failed to signal the zone state"
+        die "Failed to signal the zone state" "$out"
       fi
 
       if [[ "$out" == "READY_FOR_CUSTOMER_FACTORY_TURNUP_CHECKS" || \
@@ -129,35 +134,6 @@ steps:
         echo ">>> [Zone Status] zone signaling disabled"
         export UNDER_FACTORY_CHECKS=FALSE
       fi
-    }
-
-    function get_cluster_intent_json() {
-      cat <<EOF | jq .
-      {
-        "store_id": "${STORE_ID:-}",
-        "machine_project_id": "${MACHINE_PROJECT_ID:-}",
-        "fleet_project_id": "${FLEET_PROJECT_ID:-}",
-        "cluster_name": "${CLUSTER_NAME:-}",
-        "location": "${LOCATION:-}",
-        "node_count": "${NODE_COUNT:-}",
-        "cluster_ipv4_cidr": "${CLUSTER_IPV4_CIDR:-}",
-        "services_ipv4_cidr": "${SERVICES_IPV4_CIDR:-}",
-        "external_load_balancer_ipv4_address_pools": "${EXTERNAL_LOAD_BALANCER_IPV4_ADDRESS_POOLS:-}",
-        "sync_repo": "${SYNC_REPO:-}",
-        "sync_branch": "${SYNC_BRANCH:-}",
-        "sync_dir": "${SYNC_DIR:-}",
-        "secrets_project_id": "${SECRETS_PROJECT_ID:-}",
-        "git_token_secrets_manager_name": "${GIT_TOKEN_SECRETS_MANAGER_NAME:-}",
-        "cluster_version": "${CLUSTER_VERSION:-}",
-        "maintenance_window_start": "${MAINTENANCE_WINDOW_START:-}",
-        "maintenance_window_end": "${MAINTENANCE_WINDOW_END:-}",
-        "maintenance_window_recurrence": "${MAINTENANCE_WINDOW_RECURRENCE:-}",
-        "subnet_vlans": "${SUBNET_VLANS:-}",
-        "enable_robin_cns": "${ENABLE_ROBIN_CNS:-}",
-        "zone_name": "${ZONE_NAME_FROM_SOT:-}",
-        "labels": "${LABELS:-}"
-      }
-    EOF
     }
 
     function zone_signal() {
@@ -186,58 +162,107 @@ steps:
 
       SIGNAL_URI="${HARDWARE_MANAGEMENT_API_ENDPOINT}/${HARDWARE_MANAGEMENT_API_VERSION}/${zone_store_path}:signal"
 
-      # Use jq to safely generate JSON payload. 
-      # Manual string concatenation (e.g. "{\"key\": \"$VAL\"}") breaks if $VAL contains 
-      # unescaped double quotes (common in gcloud error messages). jq --arg handles escaping automatically.
-      if [[ $state_signal == "FACTORY_TURNUP_CHECKS_STARTED" ]]; then
-        state_signal_payload=$(jq -n --arg ss "$state_signal" --arg st "$step" '{"state_signal": $ss, "step": $st}')
-      elif [[ $state_signal == "FACTORY_TURNUP_CHECKS_FAILED" ]]; then
-        # Construct cluster_intent JSON object using the dedicated function
-        local cluster_intent_json=$(get_cluster_intent_json)
-
-        # Construct error details (ErrorInfo) safely using jq
-        local error_details=$(jq -n \
-          --arg reason "PROVISIONING_FAILED" \
-          --arg domain "acp.gdc.gke.io" \
-          --arg raw_error "$details" \
-          --arg diag "$diag_output" \
-          --arg tail "$log_tail" \
-          '[{
-            "@type": "type.googleapis.com/google.rpc.ErrorInfo",
-            "reason": $reason,
-            "domain": $domain,
-            "metadata": {
-              "raw_error": $raw_error,
-              "diagnostic_output": $diag,
-              "log_tail": $tail
-            }
-          }]')
-
-        # Construct full payload matching the new Proto contract
-        state_signal_payload=$(jq -n \
-          --arg signal "$state_signal" \
-          --arg step "$step" \
-          --arg build_id "${BUILD_ID:-}" \
-          --arg cluster_version "${CLUSTER_VERSION:-}" \
-          --argjson code "$code" \
-          --argjson intent "$cluster_intent_json" \
-          --argjson err_details "$error_details" \
-          '{
+      # Unified, elegant single jq call to build different payloads conditionally.
+      # This is robust against null/empty/special characters and guarantees valid JSON.
+      local state_signal_payload=$(jq -n \
+        --arg signal "$state_signal" \
+        --arg step "$step" \
+        --arg build_id "${BUILD_ID:-}" \
+        --arg cluster_version "${CLUSTER_VERSION:-}" \
+        --argjson code "${code:-2}" \
+        --arg reason "PROVISIONING_FAILED" \
+        --arg domain "acp.gdc.gke.io" \
+        --arg raw_error "$details" \
+        --arg diag "$diag_output" \
+        --arg tail "$log_tail" \
+        --arg store_id "${STORE_ID:-}" \
+        --arg machine_project_id "${MACHINE_PROJECT_ID:-}" \
+        --arg fleet_project_id "${FLEET_PROJECT_ID:-}" \
+        --arg cluster_name "${CLUSTER_NAME:-}" \
+        --arg location "${LOCATION:-}" \
+        --arg node_count "${NODE_COUNT:-}" \
+        --arg cluster_ipv4_cidr "${CLUSTER_IPV4_CIDR:-}" \
+        --arg services_ipv4_cidr "${SERVICES_IPV4_CIDR:-}" \
+        --arg external_load_balancer_ipv4_address_pools "${EXTERNAL_LOAD_BALANCER_IPV4_ADDRESS_POOLS:-}" \
+        --arg sync_repo "${SYNC_REPO:-}" \
+        --arg sync_branch "${SYNC_BRANCH:-}" \
+        --arg sync_dir "${SYNC_DIR:-}" \
+        --arg secrets_project_id "${SECRETS_PROJECT_ID:-}" \
+        --arg git_token_secrets_manager_name "${GIT_TOKEN_SECRETS_MANAGER_NAME:-}" \
+        --arg maintenance_window_start "${MAINTENANCE_WINDOW_START:-}" \
+        --arg maintenance_window_end "${MAINTENANCE_WINDOW_END:-}" \
+        --arg maintenance_window_recurrence "${MAINTENANCE_WINDOW_RECURRENCE:-}" \
+        --arg subnet_vlans "${SUBNET_VLANS:-}" \
+        --arg enable_robin_cns "${ENABLE_ROBIN_CNS:-}" \
+        --arg zone_name "${ZONE_NAME_FROM_SOT:-}" \
+        --arg labels "${LABELS:-}" \
+        'if $signal == "FACTORY_TURNUP_CHECKS_STARTED" then
+          {
+            state_signal: $signal,
+            step: $step
+          }
+        elif $signal == "FACTORY_TURNUP_CHECKS_FAILED" then
+          {
             state_signal: $signal,
             step: $step,
             provisioning_context: {
               build_id: $build_id,
               cluster_version: $cluster_version,
-              cluster_intent: $intent
+              cluster_intent: {
+                store_id: $store_id,
+                machine_project_id: $machine_project_id,
+                fleet_project_id: $fleet_project_id,
+                cluster_name: $cluster_name,
+                location: $location,
+                node_count: $node_count,
+                cluster_ipv4_cidr: $cluster_ipv4_cidr,
+                services_ipv4_cidr: $services_ipv4_cidr,
+                external_load_balancer_ipv4_address_pools: $external_load_balancer_ipv4_address_pools,
+                sync_repo: $sync_repo,
+                sync_branch: $sync_branch,
+                sync_dir: $sync_dir,
+                secrets_project_id: $secrets_project_id,
+                git_token_secrets_manager_name: $git_token_secrets_manager_name,
+                cluster_version: $cluster_version,
+                maintenance_window_start: $maintenance_window_start,
+                maintenance_window_end: $maintenance_window_end,
+                maintenance_window_recurrence: $maintenance_window_recurrence,
+                subnet_vlans: $subnet_vlans,
+                enable_robin_cns: $enable_robin_cns,
+                zone_name: $zone_name,
+                labels: $labels
+              }
             },
             error: {
               code: $code,
               message: $step,
-              details: $err_details
+              details: [{
+                "@type": "type.googleapis.com/google.rpc.ErrorInfo",
+                "reason": $reason,
+                "domain": $domain,
+                "metadata": {
+                  "raw_error": $raw_error,
+                  "diagnostic_output": $diag,
+                  "log_tail": $tail
+                }
+              }]
             }
-          }')
-      else
-        state_signal_payload=$(jq -n --arg ss "$state_signal" '{"state_signal": $ss}')
+          }
+        else
+          {
+            state_signal: $signal
+          }
+        end')
+
+      if [[ $? -ne 0 || -z "$state_signal_payload" ]]; then
+        echo ">>> [Zone Signal] [WARNING] Failed to construct rich payload. Falling back to original basic payload." >&2
+        if [[ "$state_signal" == "FACTORY_TURNUP_CHECKS_STARTED" ]]; then
+          state_signal_payload="{\"state_signal\": \"${state_signal}\", \"step\": \"${step}\"}"
+        elif [[ "$state_signal" == "FACTORY_TURNUP_CHECKS_FAILED" ]]; then
+          state_signal_payload="{\"state_signal\": \"${state_signal}\", \"step\": \"${step}\", \"details\": \"Provisioning failed\"}"
+        else
+          state_signal_payload="{\"state_signal\": \"${state_signal}\"}"
+        fi
       fi
 
       echo ">>> [Zone Signal] Sending '${state_signal}' to ${zone_store_path}..."
@@ -249,9 +274,13 @@ steps:
             "${SIGNAL_URI}" \
             -d "$state_signal_payload")
 
-
       if [[ $? -ne 0 ]]; then
-        die "Failed to signal the zone state"
+        if [[ "${INSIDE_DIE:-}" == "TRUE" ]]; then
+          echo ">>> [Zone Signal] [CRITICAL] Failed to send signal ${state_signal} to API while inside die." >&2
+          exit 1
+        else
+          die "Failed to signal the zone state" "$out"
+        fi
       fi
       
       echo ">>> [Zone Signal] Successfully signaled ${state_signal}."
@@ -265,7 +294,7 @@ steps:
       max_retries_for_signal_completion=10
       while [[ ${signal_attempts} -lt ${max_retries_for_signal_completion} ]]; do
         is_completed=$(curl -s -H "Authorization: Bearer $(gcloud auth print-access-token)" \
-            "${URI}" | jq -r .done)
+            "${URI}" | jq -r .done 2>/dev/null)
         
         echo ">>> [Zone Signal] Poll attempt $((signal_attempts+1))/${max_retries_for_signal_completion} - done: ${is_completed}"
         
@@ -275,7 +304,12 @@ steps:
       done
       
       if [[ ${signal_attempts} -ge ${max_retries_for_signal_completion} ]]; then
-        die "Signal operation timed out"
+        if [[ "${INSIDE_DIE:-}" == "TRUE" ]]; then
+          echo ">>> [Zone Signal] [CRITICAL] Signal operation timed out waiting for completion while inside die." >&2
+          exit 1
+        else
+          die "Signal operation timed out" "Operation $operation_id did not complete after $((max_retries_for_signal_completion * 5)) seconds."
+        fi
       else
         echo ">>> [Zone Signal] Operation completed successfully."
         return 0
@@ -288,10 +322,10 @@ steps:
 
       output=$(echo "$input" | csvtool namedcol "$column" - | csvtool drop 1 - | tr -d '"')
 
-      [[ $? -ne 0 ]] && die "[CONFIG_VALIDATION_FAILED][cluster:${CLUSTER_NAME:-unknown}] missing column header: $column" >&2
+      [[ $? -ne 0 ]] && die "[CONFIG_VALIDATION_FAILED][cluster:${CLUSTER_NAME:-unknown}] missing column header: $column" "Input data:\n$input" >&2
 
       if [ -z "$output" ]; then
-        die "[CONFIG_VALIDATION_FAILED][cluster:${CLUSTER_NAME:-unknown}] empty cell value: $column" >&2
+        die "[CONFIG_VALIDATION_FAILED][cluster:${CLUSTER_NAME:-unknown}] empty cell value: $column" "Input data:\n$input" >&2
       fi
 
       echo "$output"
@@ -326,12 +360,12 @@ steps:
       local fleet_config_path="repo/$FLEET_CONFIG_PATH"
       
       if [[ ! -f "$fleet_config_path" ]]; then
-         die "[CONFIG_VALIDATION_FAILED][cluster:${CLUSTER_NAME:-unknown}] Fleet config file not found at $fleet_config_path but required for fallback" >&2
+         die "[CONFIG_VALIDATION_FAILED][cluster:${CLUSTER_NAME:-unknown}] Fleet config file not found at $fleet_config_path but required for fallback" "Please check if the git repository contains the file at path: $FLEET_CONFIG_PATH" >&2
       fi
       local row=$(awk -F , "\$1 == \"$project_id\" || \$1 == \"\\\"$project_id\\\"\"" "$fleet_config_path")
       
       if [[ -z "$row" ]]; then
-         die "[CONFIG_VALIDATION_FAILED][cluster:${CLUSTER_NAME:-unknown}] Project $project_id not found in $fleet_config_path" >&2
+         die "[CONFIG_VALIDATION_FAILED][cluster:${CLUSTER_NAME:-unknown}] Project $project_id not found in $fleet_config_path" "File contents of $fleet_config_path:\n$(cat "$fleet_config_path" 2>/dev/null)" >&2
       fi
       
       local header=$(head -1 "$fleet_config_path")
@@ -407,13 +441,13 @@ steps:
     NODE_LOCATION=${ZONE}
     [[ -z "$NODE_LOCATION" ]] && die "[CONFIG_VALIDATION_FAILED] ZONE not set. Please ensure zone is provided in the trigger."
 
-    TOKEN=$(gcloud secrets versions access latest --secret=$GIT_SECRET_ID --project $GIT_SECRETS_PROJECT_ID) || die "[CUSTOMER_ERROR][store:${STORE_ID}] Failed to retrieve git token from Secret Manager. Please check secret name and permissions."
-    git clone -b $SOURCE_OF_TRUTH_BRANCH https://oauth2:$TOKEN@$SOURCE_OF_TRUTH_REPO repo || die "[CUSTOMER_ERROR][store:${STORE_ID}] Failed to clone source of truth repository. Please check repo URL and branch."
-    cp repo/$SOURCE_OF_TRUTH_PATH ./cluster-intent-registry.csv || die "[CUSTOMER_ERROR][store:${STORE_ID}] Failed to copy cluster intent file. Please check if SOURCE_OF_TRUTH_PATH is correct."
+    TOKEN=$(gcloud secrets versions access latest --secret=$GIT_SECRET_ID --project $GIT_SECRETS_PROJECT_ID) || die "[CUSTOMER_ERROR][store:${STORE_ID}] Failed to retrieve git token from Secret Manager" "Secret name: $GIT_SECRET_ID, Project ID: $GIT_SECRETS_PROJECT_ID"
+    git clone -b $SOURCE_OF_TRUTH_BRANCH https://oauth2:$TOKEN@$SOURCE_OF_TRUTH_REPO repo || die "[CUSTOMER_ERROR][store:${STORE_ID}] Failed to clone source of truth repository" "Repo: $SOURCE_OF_TRUTH_REPO, Branch: $SOURCE_OF_TRUTH_BRANCH"
+    cp repo/$SOURCE_OF_TRUTH_PATH ./cluster-intent-registry.csv || die "[CUSTOMER_ERROR][store:${STORE_ID}] Failed to copy cluster intent file" "Source of truth path: $SOURCE_OF_TRUTH_PATH"
 
     export CLUSTER_INTENT_ROW=$(awk -F , "\$1 == \"$STORE_ID\" || \$1 == \"\\\"$STORE_ID\\\"\"" cluster-intent-registry.csv)
     echo ">>> [SoT Parse] $CLUSTER_INTENT_ROW"
-    [[ -z "$CLUSTER_INTENT_ROW" ]] && die "[CONFIG_VALIDATION_FAILED] Cluster intent not found for store: $STORE_ID"
+    [[ -z "$CLUSTER_INTENT_ROW" ]] && die "[CONFIG_VALIDATION_FAILED] Cluster intent not found for store: $STORE_ID" "Store ID: $STORE_ID, Intent CSV file contents:\n$(cat cluster-intent-registry.csv 2>/dev/null)"
     export CLUSTER_INTENT_HEADER=$(head -1 cluster-intent-registry.csv)
     export CLUSTER_INTENT="$CLUSTER_INTENT_HEADER"$'\n'"$CLUSTER_INTENT_ROW"
 

--- a/module/create-cluster.yaml
+++ b/module/create-cluster.yaml
@@ -80,6 +80,49 @@ steps:
       zone_signal "$ZONE_ID" FACTORY_TURNUP_CHECKS_STARTED "$message"
     )
 
+    # Retrieves a compact, single-line diagnostic summary of cluster nodes and optional namespace.
+    # It makes exactly 1 kubectl API request for nodes to prevent overloading the API Server.
+    #
+    # Ideal Output Examples (Healthy):
+    #   - With namespace parameter:
+    #     "Cluster: Connected | Nodes: 3/3 Ready | Namespace: config-management-system (Active)"
+    #   - Without namespace parameter:
+    #     "Cluster: Connected | Nodes: 3/3 Ready"
+    #
+    # Unhealthy Output Example (e.g. Node 3 is NotReady):
+    #     "Cluster: Connected | Nodes: 2/3 Ready (Unhealthy: gmec-bjc9003.ba.l.google.com) | Namespace: config-management-system (Active)"
+    #
+    # Unreachable Output Example:
+    #     "Cluster Status: Unreachable"
+    function get_cluster_diag_info() {
+      local target_ns=$1
+      local ns_status_str=""
+      
+      local node_info
+      if ! node_info=$(kubectl get nodes --no-headers 2>/dev/null); then
+        echo "Cluster Status: Unreachable"
+        return
+      fi
+
+      local total_nodes=$(echo "$node_info" | wc -l || echo "0")
+      local ready_nodes=$(echo "$node_info" | grep -c ' Ready' || echo "0")
+      
+      local unhealthy_list=""
+      if [[ $ready_nodes -lt $total_nodes ]]; then
+        local names=$(echo "$node_info" | grep -v ' Ready' | awk '{print $1}' | tr '\n' ',' | sed 's/,$//')
+        unhealthy_list=" (Unhealthy: $names)"
+      fi
+
+      # Attach target namespace status if provided
+      if [[ -n "$target_ns" ]]; then
+        local ns_status=$(kubectl get ns "$target_ns" --no-headers 2>/dev/null | awk '{print $2}')
+        [[ -z "$ns_status" ]] && ns_status="NOT_FOUND"
+        ns_status_str=" | Namespace: $target_ns ($ns_status)"
+      fi
+
+      echo "Cluster: Connected | Nodes: $ready_nodes/$total_nodes Ready$unhealthy_list$ns_status_str"
+    }
+
     # Sets the `UNDER_FACTORY_CHECKS` to either true if ZoneState is ready, started, or failed
     # or false for all other ZoneStates or for provisioning that bypasses the ZoneState.
     function set_factory_check_flag() {
@@ -143,7 +186,8 @@ steps:
 
       # Unified, elegant single jq call to build different payloads conditionally.
       # This is robust against null/empty/special characters and guarantees valid JSON.
-      local state_signal_payload=$(jq -n \
+      local state_signal_payload
+      state_signal_payload=$(jq -n \
         --arg signal "$state_signal" \
         --arg step "$step" \
         --arg build_id "${BUILD_ID:-}" \
@@ -445,8 +489,11 @@ steps:
     assign_required SYNC_DIR "sync_dir"
     assign_required SECRETS_PROJECT_ID "secrets_project_id"
     assign_required GIT_TOKEN_SECRETS_MANAGER_NAME "git_token_secrets_manager_name"
-    
-    export CLUSTER_VERSION=$(resolve_cluster_version "$CLUSTER_INTENT" "$FLEET_PROJECT_ID") || exit 1
+    CLUSTER_VERSION_RESOLVED=$(resolve_cluster_version "$CLUSTER_INTENT" "$FLEET_PROJECT_ID")
+    if [[ $? -ne 0 ]]; then
+      exit 1
+    fi
+    export CLUSTER_VERSION="$CLUSTER_VERSION_RESOLVED"
     
     export MAINTENANCE_WINDOW_START=$(parse_csv_optional "$CLUSTER_INTENT" "maintenance_window_start")
     export MAINTENANCE_WINDOW_END=$(parse_csv_optional "$CLUSTER_INTENT" "maintenance_window_end")
@@ -540,8 +587,6 @@ steps:
       [[ -n "${IDENTITY_SERVICE_ARG}" ]] && CMD_ARGS+=("${IDENTITY_SERVICE_ARG}")
       [[ -n "${ROBIN_CNS_ARG}" ]] && CMD_ARGS+=("${ROBIN_CNS_ARG}")
 
-      echo ">>> [Cluster Create] Executing command: $GCLOUD_CMD ${CMD_ARGS[*]}"
-
       out=$(
         $GCLOUD_CMD "${CMD_ARGS[@]}" 2>&1 | tee /dev/fd/5
       )
@@ -625,26 +670,24 @@ steps:
     set +e # Temporarily disable errexit to safely capture PIPESTATUS
     trap - ERR # Prevent trap from hijacking pipe errors
 
-    kubectl create ns config-management-system --dry-run=client -o yaml | kubectl apply -f -
-    rcs=("${PIPESTATUS[@]}")
-    if [[ ${rcs[0]} -ne 0 || ${rcs[1]} -ne 0 ]]; then
-      diag=$(kubectl cluster-info 2>/dev/null || echo "[DIAGNOSTIC_FAILED] Cluster unreachable")
-      [[ ${rcs[0]} -ne 0 ]] && die "Failed to create namespace" "Command failed: kubectl create ns config-management-system --dry-run=client -o yaml (Exit code: ${rcs[0]})" 2 "$diag"
-      [[ ${rcs[1]} -ne 0 ]] && die "Failed to apply namespace" "Command failed: kubectl apply -f - (Exit code: ${rcs[1]})" 2 "$diag"
-    fi
+    out=$( (kubectl create ns config-management-system --dry-run=client -o yaml | kubectl apply -f -) 2>&1 ) || {
+      rc=$?
+      set +x
+      diag=$(get_cluster_diag_info "config-management-system")
+      die "Failed to configure namespace" "$out (Exit code: $rc)" 2 "$diag"
+    }
 
     set +x
-    kubectl create secret generic git-creds --namespace="config-management-system" \
+    out=$( (kubectl create secret generic git-creds --namespace="config-management-system" \
         --from-literal=username=default --from-file=token="$(pwd)/git-creds" \
-        --dry-run=client -o yaml | kubectl apply -f -
-    rcs=("${PIPESTATUS[@]}")
-    set -x
-    if [[ ${rcs[0]} -ne 0 || ${rcs[1]} -ne 0 ]]; then
-      diag=$(kubectl cluster-info 2>/dev/null || echo "Cluster unreachable")
-      [[ ${rcs[0]} -ne 0 ]] && die "Failed to create secret" "Command failed: kubectl create secret generic git-creds ... (Exit code: ${rcs[0]})" 2 "$diag"
-      [[ ${rcs[1]} -ne 0 ]] && die "Failed to apply secret" "Command failed: kubectl apply -f - (Exit code: ${rcs[1]})" 2 "$diag"
-    fi
+        --dry-run=client -o yaml | kubectl apply -f -) 2>&1 ) || {
+      rc=$?
+      set +x
+      diag=$(get_cluster_diag_info "config-management-system")
+      die "Failed to configure secret" "$out (Exit code: $rc)" 2 "$diag"
+    }
 
+    set -x
     out=$(gcloud beta container fleet config-management apply --membership=$CLUSTER_NAME \
         --config=./apply-spec.yaml --project $FLEET_PROJECT_ID 2>&1)
     rc=$?
@@ -655,12 +698,14 @@ steps:
     fi
 
     out=$(gcloud storage cp gs://$CLUSTER_INTENT_BUCKET/fleet-packages-rbac.yaml.template . 2>&1) || die "Failed to copy fleet packages RBAC template" "$out"
-    export PROJECT_NUMBER=$(gcloud projects describe $FLEET_PROJECT_ID --format="value(projectNumber)" 2>&1) || die "Failed to describe project" "$PROJECT_NUMBER"
+    PROJECT_NUMBER_RESOLVED=$(gcloud projects describe $FLEET_PROJECT_ID --format="value(projectNumber)" 2>&1) || die "Failed to describe project" "$PROJECT_NUMBER_RESOLVED"
+    export PROJECT_NUMBER="$PROJECT_NUMBER_RESOLVED"
     
     out=$(envsubst < fleet-packages-rbac.yaml.template > fleet-packages-rbac.yaml 2>&1) || die "Failed to substitute environment variables in template" "$out"
 
     out=$(kubectl apply -f fleet-packages-rbac.yaml 2>&1) || {
-      diag=$(kubectl cluster-info 2>/dev/null || echo "[DIAGNOSTIC_FAILED] Cluster unreachable")
+      set +x
+      diag=$(get_cluster_diag_info)
       die "Failed to apply fleet packages RBAC" "$out" 2 "$diag"
     }
 
@@ -668,10 +713,9 @@ steps:
     if [[ "${SKIP_IDENTITY_SERVICE}" == "FALSE" ]] &&  ! gdc_version_evaluate "${CLUSTER_VERSION}" "1.10.0"; then
       log_build_step "Configuring manual Group RBAC"
       FLEET_PROJECT_NUMBER=$(gcloud projects describe $FLEET_PROJECT_ID --format='value(projectNumber)' 2>&1) || die "Failed to describe project for Group RBAC" "$FLEET_PROJECT_NUMBER"
-      kubectl patch clientconfig default -n kube-public --type=merge -p '{"spec":{"authentication":[{"google":{"audiences":["//'${GKEHUB_API_ENDPOINT}'/projects/'${FLEET_PROJECT_NUMBER}'/locations/global/memberships/'${CLUSTER_NAME}'"]},"name":"google-authentication-method"}]}}' || {
-        rc=$?
+      out=$(kubectl patch clientconfig default -n kube-public --type=merge -p '{"spec":{"authentication":[{"google":{"audiences":["//'${GKEHUB_API_ENDPOINT}'/projects/'${FLEET_PROJECT_NUMBER}'/locations/global/memberships/'${CLUSTER_NAME}'"]},"name":"google-authentication-method"}]}}' 2>&1) || {
         diag=$(kubectl get clientconfig default -n kube-public -o yaml 2>/dev/null || echo "[DIAGNOSTIC_FAILED] Failed to get clientconfig status")
-        die "Failed to patch clientconfig for Group RBAC" "Exit code: $rc" 2 "$diag"
+        die "Failed to patch clientconfig for Group RBAC" "$out" 2 "$diag"
       }
       log_build_step "Group RBAC applied"
     else
@@ -728,7 +772,7 @@ steps:
     fail=0
     for vm in $vms; do
       echo ">>> [Cluster Create] Shutting down $vm"
-      ./virtctl stop -n vm-workloads $vm || fail=1
+      ./virtctl stop -n vm-workloads $vm || { echo ">>> [Cluster Create] Failed to stop $vm"; fail=1; }
     done
     if [[ $fail -ne 0 ]]; then
       diag=$(kubectl get vmi -n vm-workloads -o yaml 2>/dev/null || echo "[DIAGNOSTIC_FAILED] Failed to get VMI status")

--- a/module/create-cluster.yaml
+++ b/module/create-cluster.yaml
@@ -699,13 +699,17 @@ steps:
       set +x
       diag=$(
         kubectl get -f fleet-packages-rbac.yaml -o json 2>/dev/null | jq '
-          .items[] | {
-            kind: .kind,
-            name: .metadata.name,
-            namespace: (.metadata.namespace // empty),
-            created: .metadata.creationTimestamp,
-            subjects: (.subjects // empty)
-          } // empty
+          if (.items | length) == 0 then
+            "No RBAC resources found in the cluster"
+          else
+            .items[] | {
+              kind: .kind,
+              name: .metadata.name,
+              namespace: .metadata.namespace,
+              created: .metadata.creationTimestamp,
+              subjects: .subjects
+            }
+          end
         ' || echo "[DIAGNOSTIC_FAILED] Failed to get fleet packages RBAC status"
       )
       die "Failed to apply fleet packages RBAC" "$out" 2 "$diag"
@@ -735,6 +739,22 @@ steps:
       # State flag for ConfigSync sequential checks
       config_sync_ok=true
 
+      # Check if we are using GKE Hub-managed ConfigSync (v1.21.0+) or legacy ConfigManagement (< v1.21.0)
+      is_modern_config_sync=true
+      if [[ -n "${CS_VERSION}" ]] && ! gdc_version_evaluate "${CS_VERSION}" "1.21.0"; then
+        is_modern_config_sync=false
+      fi
+
+      resource_kind="configsyncs.configdelivery.gke.io"
+      resource_name="config-sync"
+      err_jsonpath='{.status.conditions[?(@.type=="Ready")].message}'
+
+      if [[ "$is_modern_config_sync" == "false" ]]; then
+        resource_kind="configmanagements.configmanagement.gke.io"
+        resource_name="config-management"
+        err_jsonpath='{.status.errors[0]}'
+      fi
+
       # Check 1: Check for ConfigSync CRD to be created (Non-blocking telemetry check)
       count=0
       max_retries_for_crd_creation=60 # 5 min
@@ -756,7 +776,7 @@ steps:
         max_retries_for_configsync_creation=60 # 5 min
         log_build_step "Waiting for ConfigSync custom resource to be created"
         while [[ ${count} -lt ${max_retries_for_configsync_creation} ]]; do
-          kubectl get configsyncs.configdelivery.gke.io config-sync >/dev/null 2>&1 && break
+          kubectl get ${resource_kind} ${resource_name} >/dev/null 2>&1 && break
           sleep 5
           ((count++))
         done
@@ -766,7 +786,7 @@ steps:
           log_build_step "[WARNING] ConfigSync custom resource not created after 5min. Proceeding to default health checks..."
         else
           # Retrieve Hub API Checkpoint (Start Time) from config-sync annotation
-          config_sync_json=$(kubectl get configsyncs.configdelivery.gke.io config-sync -o json 2>/dev/null)
+          config_sync_json=$(kubectl get ${resource_kind} ${resource_name} -o json 2>/dev/null)
           creation_time=$(printf '%s\n' "$config_sync_json" | jq -r '.metadata.creationTimestamp // empty' 2>/dev/null)
           update_time=$(printf '%s\n' "$config_sync_json" | jq -r '.metadata.annotations["configmanagement.gke.io/update-time"] // empty' 2>/dev/null)
           log_build_step "ConfigSync custom resource detected (Created: ${creation_time:-unknown}, Hub API Start Time: ${update_time:-unknown})"
@@ -779,7 +799,7 @@ steps:
         max_retries_for_configsync_healthy=120 # 10 min
         log_build_step "Waiting for ConfigSync custom resource to be healthy"
         while [[ ${count} -lt ${max_retries_for_configsync_healthy} ]]; do
-          healthy=$(kubectl get configsyncs.configdelivery.gke.io config-sync -o jsonpath='{.status.healthy}' 2>/dev/null)
+          healthy=$(kubectl get ${resource_kind} ${resource_name} -o jsonpath='{.status.healthy}' 2>/dev/null)
           if [[ "$healthy" == "true" ]]; then
             log_build_step "ConfigSync custom resource is healthy"
             break
@@ -789,13 +809,13 @@ steps:
         done
         if [[ ${count} -ge ${max_retries_for_configsync_healthy} ]]; then
           # Extract concise, single-line error messages for HWM telemetry
-          config_sync_err=$(kubectl get configsyncs.configdelivery.gke.io config-sync -o jsonpath='{.status.conditions[?(@.type=="Ready")].message}' 2>/dev/null)
+          config_sync_err=$(kubectl get ${resource_kind} ${resource_name} -o jsonpath="${err_jsonpath}" 2>/dev/null)
           root_sync_err=$(kubectl get rootsyncs.configsync.gke.io -n config-management-system root-sync -o jsonpath='{.status.conditions[?(@.status=="True")].message}' 2>/dev/null)
 
           log_build_step "[WARNING] ConfigSync not healthy. Reason: ${config_sync_err:-unknown}. RootSync Error: ${root_sync_err:-none}. Proceeding to default health checks..."
           
           # Dump detailed reports to console for human debugging
-          kubectl describe configsyncs.configdelivery.gke.io config-sync 2>/dev/null
+          kubectl describe ${resource_kind} ${resource_name} 2>/dev/null
           kubectl describe rootsyncs.configsync.gke.io -n config-management-system root-sync 2>/dev/null
         fi
       fi
@@ -866,14 +886,18 @@ steps:
     if [[ $fail -ne 0 ]]; then
       diag=$(
         kubectl get vmi -n vm-workloads -o json 2>/dev/null | jq '
-          .items[] | {
-            name: .metadata.name,
-            node: .status.nodeName,
-            phase: .status.phase,
-            terminating_since: .metadata.deletionTimestamp,
-            conditions: [.status.conditions[]? | {type: .type, status: .status, reason: .reason, message: .message}],
-            migration: (if .status.migrationState then (.status.migrationState | {source: .sourceNode, target: .targetNode, status: .status, error: .abortReason}) else empty end)
-          } // empty
+          if (.items | length) == 0 then
+            "No running VMs found in namespace vm-workloads"
+          else
+            .items[] | {
+              name: .metadata.name,
+              node: .status.nodeName,
+              phase: .status.phase,
+              terminating_since: .metadata.deletionTimestamp,
+              conditions: [.status.conditions[]? | {type: .type, status: .status, reason: .reason, message: .message}],
+              migration: (if .status.migrationState then (.status.migrationState | {source: .sourceNode, target: .targetNode, status: .status, error: .abortReason}) else null end)
+            }
+          end
         ' || echo "[DIAGNOSTIC_FAILED] Failed to get VMI status"
       )
       die "Unsuccessful VM termination sequence" "Failed to stop all VMs" 2 "$diag"

--- a/module/create-cluster.yaml
+++ b/module/create-cluster.yaml
@@ -80,49 +80,6 @@ steps:
       zone_signal "$ZONE_ID" FACTORY_TURNUP_CHECKS_STARTED "$message"
     )
 
-    # Retrieves a compact, single-line diagnostic summary of cluster nodes and optional namespace.
-    # It makes exactly 1 kubectl API request for nodes to prevent overloading the API Server.
-    #
-    # Ideal Output Examples (Healthy):
-    #   - With namespace parameter:
-    #     "Cluster: Connected | Nodes: 3/3 Ready | Namespace: config-management-system (Active)"
-    #   - Without namespace parameter:
-    #     "Cluster: Connected | Nodes: 3/3 Ready"
-    #
-    # Unhealthy Output Example (e.g. Node 3 is NotReady):
-    #     "Cluster: Connected | Nodes: 2/3 Ready (Unhealthy: gmec-bjc9003.ba.l.google.com) | Namespace: config-management-system (Active)"
-    #
-    # Unreachable Output Example:
-    #     "Cluster Status: Unreachable"
-    function get_cluster_diag_info() {
-      local target_ns=$1
-      local ns_status_str=""
-      
-      local node_info
-      if ! node_info=$(kubectl get nodes --no-headers 2>/dev/null); then
-        echo "Cluster Status: Unreachable"
-        return
-      fi
-
-      local total_nodes=$(echo "$node_info" | wc -l || echo "0")
-      local ready_nodes=$(echo "$node_info" | grep -c ' Ready' || echo "0")
-      
-      local unhealthy_list=""
-      if [[ $ready_nodes -lt $total_nodes ]]; then
-        local names=$(echo "$node_info" | grep -v ' Ready' | awk '{print $1}' | tr '\n' ',' | sed 's/,$//')
-        unhealthy_list=" (Unhealthy: $names)"
-      fi
-
-      # Attach target namespace status if provided
-      if [[ -n "$target_ns" ]]; then
-        local ns_status=$(kubectl get ns "$target_ns" --no-headers 2>/dev/null | awk '{print $2}')
-        [[ -z "$ns_status" ]] && ns_status="NOT_FOUND"
-        ns_status_str=" | Namespace: $target_ns ($ns_status)"
-      fi
-
-      echo "Cluster: Connected | Nodes: $ready_nodes/$total_nodes Ready$unhealthy_list$ns_status_str"
-    }
-
     # Sets the `UNDER_FACTORY_CHECKS` to either true if ZoneState is ready, started, or failed
     # or false for all other ZoneStates or for provisioning that bypasses the ZoneState.
     function set_factory_check_flag() {
@@ -684,7 +641,7 @@ steps:
     out=$( (kubectl create ns config-management-system --dry-run=client -o yaml | kubectl apply -f -) 2>&1 ) || {
       rc=$?
       set +x
-      diag=$(get_cluster_diag_info "config-management-system")
+      diag=$(kubectl get ns config-management-system -o yaml 2>/dev/null || echo "[DIAGNOSTIC_FAILED] Failed to get namespace status")
       die "Failed to configure namespace" "$out (Exit code: $rc)" 2 "$diag"
     }
 
@@ -694,7 +651,16 @@ steps:
         --dry-run=client -o yaml | kubectl apply -f -) 2>&1 ) || {
       rc=$?
       set +x
-      diag=$(get_cluster_diag_info "config-management-system")
+      diag=$(
+        kubectl get secret git-creds -n config-management-system -o json 2>/dev/null | jq '
+          {
+            name: .metadata.name,
+            type: .type,
+            created: .metadata.creationTimestamp,
+            data_keys: (.data | keys)
+          } // empty
+        ' || echo "[DIAGNOSTIC_FAILED] Failed to get secret status"
+      )
       die "Failed to configure secret" "$out (Exit code: $rc)" 2 "$diag"
     }
 
@@ -704,7 +670,22 @@ steps:
     rc=$?
     set -e
     if [[ $rc -ne 0 ]]; then
-      diag=$(kubectl get rootsync -n config-management-system -o yaml 2>/dev/null || echo "[DIAGNOSTIC_FAILED] Failed to get RootSync status")
+      diag=$(
+        kubectl get rootsync root-sync -n config-management-system -o json 2>/dev/null | jq '
+          {
+            repo: .spec.git.repo,
+            dir: .spec.git.dir,
+            last_synced_commit: .status.lastSyncedCommit,
+            conditions: [.status.conditions[]? | {
+              type: .type,
+              status: .status,
+              message: .message
+            }],
+            render_errors: .status.rendering.errors,
+            sync_errors: .status.sync.errors
+          } // empty
+        ' || echo "[DIAGNOSTIC_FAILED] Failed to get RootSync status"
+      )
       die "Config Sync apply failed" "$out" 2 "$diag"
     fi
 
@@ -716,7 +697,17 @@ steps:
 
     out=$(kubectl apply -f fleet-packages-rbac.yaml 2>&1) || {
       set +x
-      diag=$(get_cluster_diag_info)
+      diag=$(
+        kubectl get -f fleet-packages-rbac.yaml -o json 2>/dev/null | jq '
+          .items[] | {
+            kind: .kind,
+            name: .metadata.name,
+            namespace: (.metadata.namespace // empty),
+            created: .metadata.creationTimestamp,
+            subjects: (.subjects // empty)
+          } // empty
+        ' || echo "[DIAGNOSTIC_FAILED] Failed to get fleet packages RBAC status"
+      )
       die "Failed to apply fleet packages RBAC" "$out" 2 "$diag"
     }
 
@@ -725,7 +716,11 @@ steps:
       log_build_step "Configuring manual Group RBAC"
       FLEET_PROJECT_NUMBER=$(gcloud projects describe $FLEET_PROJECT_ID --format='value(projectNumber)' 2>&1) || die "Failed to describe project for Group RBAC" "$FLEET_PROJECT_NUMBER"
       out=$(kubectl patch clientconfig default -n kube-public --type=merge -p '{"spec":{"authentication":[{"google":{"audiences":["//'${GKEHUB_API_ENDPOINT}'/projects/'${FLEET_PROJECT_NUMBER}'/locations/global/memberships/'${CLUSTER_NAME}'"]},"name":"google-authentication-method"}]}}' 2>&1) || {
-        diag=$(kubectl get clientconfig default -n kube-public -o yaml 2>/dev/null || echo "[DIAGNOSTIC_FAILED] Failed to get clientconfig status")
+        diag=$(
+          kubectl get clientconfig default -n kube-public -o json 2>/dev/null | jq '
+            {authentication: .spec.authentication, status: .status} // empty
+          ' || echo "[DIAGNOSTIC_FAILED] Failed to get clientconfig status"
+        )
         die "Failed to patch clientconfig for Group RBAC" "$out" 2 "$diag"
       }
       log_build_step "Group RBAC applied"
@@ -814,13 +809,24 @@ steps:
         ((count++))
       done
       if [[ ${count} -ge ${max_retries_for_healthcheck_creation} ]]; then
-        diag=$(kubectl get crd healthchecks.validator.gdc.gke.io -o yaml 2>/dev/null || echo "[DIAGNOSTIC_FAILED] CRD not found")
+        diag=$(
+          kubectl get crd healthchecks.validator.gdc.gke.io -o json 2>/dev/null | jq '
+            {
+              name: .metadata.name,
+              conditions: [.status.conditions[]? | {type: .type, status: .status, reason: .reason, message: .message}]
+            } // empty
+          ' || echo "[DIAGNOSTIC_FAILED] CRD not found"
+        )
         die "Health check resource not created after 20min" "Timeout waiting for resource creation" 4 "$diag"
       fi
 
       log_build_step "Waiting for platform healthchecks to pass"
       if ! kubectl wait healthchecks.validator.gdc.gke.io/default --for condition=PlatformHealthy --timeout=1h; then
-        diag=$(kubectl get healthchecks.validator.gdc.gke.io/default -o yaml 2>/dev/null || echo "Failed to get healthcheck status")
+        diag=$(
+          kubectl get healthchecks.validator.gdc.gke.io/default -o json 2>/dev/null | jq '
+            [.status.conditions[]? | {type: .type, status: .status, reason: .reason, message: .message}] // empty
+          ' || echo "Failed to get healthcheck status"
+        )
         die "Platform is not healthy after 1h" "Timeout waiting for condition=PlatformHealthy" 4 "$diag"
       fi
 
@@ -831,7 +837,11 @@ steps:
 
       log_build_step "Waiting for workload healthchecks to pass"
       if ! kubectl wait healthchecks.validator.gdc.gke.io/default --for condition=WorkloadsHealthy --timeout="${WORKLOAD_TIMEOUT}s"; then
-        diag=$(kubectl get healthchecks.validator.gdc.gke.io/default -o yaml 2>/dev/null || echo "Failed to get healthcheck status")
+        diag=$(
+          kubectl get healthchecks.validator.gdc.gke.io/default -o json 2>/dev/null | jq '
+            [.status.conditions[]? | {type: .type, status: .status, reason: .reason, message: .message}] // empty
+          ' || echo "Failed to get healthcheck status"
+        )
         die "[CUSTOMER_ERROR] Workloads are not healthy after ${WORKLOAD_TIMEOUT}s" "Timeout waiting for condition=WorkloadsHealthy" 4 "$diag"
       fi
     fi
@@ -854,7 +864,18 @@ steps:
       ./virtctl stop -n vm-workloads $vm || { echo ">>> [Cluster Create] Failed to stop $vm"; fail=1; }
     done
     if [[ $fail -ne 0 ]]; then
-      diag=$(kubectl get vmi -n vm-workloads -o yaml 2>/dev/null || echo "[DIAGNOSTIC_FAILED] Failed to get VMI status")
+      diag=$(
+        kubectl get vmi -n vm-workloads -o json 2>/dev/null | jq '
+          .items[] | {
+            name: .metadata.name,
+            node: .status.nodeName,
+            phase: .status.phase,
+            terminating_since: .metadata.deletionTimestamp,
+            conditions: [.status.conditions[]? | {type: .type, status: .status, reason: .reason, message: .message}],
+            migration: (if .status.migrationState then (.status.migrationState | {source: .sourceNode, target: .targetNode, status: .status, error: .abortReason}) else empty end)
+          } // empty
+        ' || echo "[DIAGNOSTIC_FAILED] Failed to get VMI status"
+      )
       die "Unsuccessful VM termination sequence" "Failed to stop all VMs" 2 "$diag"
     fi
 


### PR DESCRIPTION
## Description

This PR implements the client-side logic in `create-cluster.yaml` to fulfill the new rich failure signaling contract between the Automated Cluster Provisioner (ACP) and the Hardware Management (HWM) API.

Instead of using the now-deprecated flat `details` string, this change populates the newly defined strongly-typed fields in `SignalZoneStateRequest` (mapped via JSON REST gateway) to provide deep observability and enable automated failure categorization on the HWM side.

## Key Changes

### API Contract & Observability
- **Rich Payload**: Populated `provisioning_context` (intent, build ID, version) and standard `error` (`google.rpc.Status`) in the failure payload.
- **Log Tail**: Captured the last 30 lines of the execution log on failure to provide operational context.
- **Conditional Diagnostics**: Added targeted `kubectl` dumps (RootSync, HealthChecks, VMI) depending on the specific failure point to assist in debugging.

### Code Quality & Safety (Refactor)
- **Refactored Error Handling**: Replaced repetitive and noisy `set +e` / `set -e` blocks with clean `|| die` or `|| { ... }` patterns, significantly improving readability.
- **Log Sanitization**: Stripped progress dots from `gcloud` and ANSI color codes from command outputs to keep the transmitted logs clean and readable.
- **Standard Error Capture**: Ensured `2>&1` is used on all critical `gcloud` calls to guarantee error messages are captured and not lost in standard error.

### Testing Report
#### Corner Case 1: If jq fails or encounters a runtime exception during rich payload construction, it will not interrupt the Cloud Build execution. Instead, it degrades and automatically falls back to the basic payload (empty logs) to guarantee status delivery.

```
jq: invalid JSON text passed to --argjson
  | Use jq --help for help with command-line options,
  | or see the jq manpage, or online docs  at https://jqlang.github.io/jq
  | >>> [Zone Signal] [WARNING] Failed to construct rich payload. Falling back to original basic payload.
  | >>> [Zone Signal] Sending 'FACTORY_TURNUP_CHECKS_FAILED' to projects/edgesites-baremetal-lab-qual/locations/us-central1/zones/gmec-bjc90...
  | >>> [Zone Signal] Payload: {"state_signal": "FACTORY_TURNUP_CHECKS_FAILED", "step": "[Build: 18b48b3a-b99e-4017-b662-ea055427ddc5] [CONFIG_VALIDATION_FAILED][cluster:wei-acp-dev-cluster] Fleet config file not found at repo/fleet-version-config.csv but required for fallback", "details": "Provisioning failed"}
  | >>> [Zone Signal] Successfully signaled FACTORY_TURNUP_CHECKS_FAILED.
```
Also verified in HWM API:
<img width="1484" height="127" alt="image" src="https://github.com/user-attachments/assets/b6647638-1be2-4321-a97e-1a954cd9e950" />

#### Corner Case 2: If the zone_signal API call fails while executing inside the die() function, the system actively prevents recursive loops. The recursion guard (INSIDE_DIE) intercepts the failure and immediately terminates the execution, ensuring a clean exit instead of entering an infinite recursion loop.

```
>>> [Zone Signal] [CRITICAL] Failed to send signal FACTORY_TURNUP_CHECKS_FAILED to API while inside die.
--
  | ERROR
  | ERROR: build step 0 "gcr.io/google.com/cloudsdktool/cloud-sdk" failed: step exited with non-zero status: 1
```

#### Test Scenario: Command Error captured by PIPESTATUS
```
   # when kubectl apply -f - failed, rcs will capture the error.
    kubectl create ns config-management-system --dry-run=client -o yaml | kubectl apply -f -
    rcs=("${PIPESTATUS[@]}")
```
Here is the error HWM API get
```
      "error":  {
        "code":  2,
        "message":  "[Build: 2b3c1254-9b82-41e5-9544-69ce2b9fe0e4] Failed to apply namespace",
        "details":  [
          {
            "@type":  "type.googleapis.com/google.rpc.ErrorInfo",
            "reason":  "PROVISIONING_FAILED",
            "domain":  "acp.gdc.gke.io",
            "metadata":  {
              "diagnostic_output":  "Cluster: Connected | Nodes: 3/3 Ready | Namespace: config-management-system (Active)",
              "log_tail":  "+ out='Copying gs://gdce-cluster-provisioner-bucket-acp-dev-e32f4403390fbe17/apply-spec.yaml.template to file://./apply-spec.yaml.template\n  \n.'\n+ [[ -n 1.18.3 ]]\n+ export 'CS_VERSION_YAML=version: 1.18.3'\n+ CS_VERSION_YAML='version: 1.18.3'\n++ envsubst\n+ out=\n+ set +x\n>>> [Build Step] [Build: 2b3c1254-9b82-41e5-9544-69ce2b9fe0e4] Configuring configsync\n>>> [Zone Signal] Sending 'FACTORY_TURNUP_CHECKS_STARTED' to projects/edgesites-baremetal-lab-qual/locations/us-central1/zones/gmec-bjc90...\n>>> [Zone Signal] Payload: {\n  \"state_signal\": \"FACTORY_TURNUP_CHECKS_STARTED\",\n  \"step\": \">>> [Build Step] [Build: 2b3c1254-9b82-41e5-9544-69ce2b9fe0e4] Configuring configsync\"\n}\n>>> [Zone Signal] Successfully signaled FACTORY_TURNUP_CHECKS_STARTED.\n>>> [Zone Signal] Operation ID: projects/edgesites-baremetal-lab-qual/locations/us-central1/operations/operation-1779238136231-652352914b752-69982690-fd543973\n>>> [Zone Signal] Waiting for operation to complete...\n>>> [Zone Signal] Poll attempt 1/10 - done: true\n>>> [Zone Signal] Operation completed successfully.\n+ set +e\n+ trap - ERR\n+ kubectl create ns config-management-system --dry-run=client -o yaml\n+ kubectl apply -f - --invalid\nerror: unknown flag: --invalid\nSee 'kubectl apply --help' for usage.\n+ rcs=(\"${PIPESTATUS[@]}\")\n+ [[ 0 -ne 0 ]]\n+ [[ 1 -ne 0 ]]\n+ set +x",
              "raw_error":  "Command failed: kubectl apply -f - (Exit code: 1)"
            }
          }
        ]
      }
```

#### Regular Scenario Test
```
# Logs from ACP shows that we are sending correct data payload to HWM API

>>> [Zone Signal] Sending 'FACTORY_TURNUP_CHECKS_FAILED' to projects/edgesites-baremetal-lab-qual/locations/us-central1/zones/gmec-bjc90...
--
  | >>> [Zone Signal] Payload: {
  | "state_signal": "FACTORY_TURNUP_CHECKS_FAILED",
  | "step": "[Build: 3c67ed68-16f1-4879-baaa-3a6b4a972825] Failure from gcloud edge-cloud container clusters create command",
  | "provisioning_context": {
  | "build_id": "3c67ed68-16f1-4879-baaa-3a6b4a972825",
  | "cluster_version": "1.12.0-gdce.68",
  | "cluster_intent": {
  | "store_id": "gmec-bjc90",
  | "machine_project_id": "edgesites-baremetal-lab-qual",
  | "fleet_project_id": "cloud-alchemists-sandbox",
  | "cluster_name": "wei-acp-dev-cluster",
  | "location": "us-central1",
  | "node_count": "3",
  | "cluster_ipv4_cidr": "172.16.0.0/17",
  | "services_ipv4_cidr": "192.168.30.0/23",
  | "external_load_balancer_ipv4_address_pools": "172.20.100.241-172.20.100.246",
  | "sync_repo": "https://gitlab.com/weiww2/primary-root-repo",
  | "sync_branch": "main",
  | "sync_dir": "/config/clusters/wei-acp-dev-cluster/meta",
  | "secrets_project_id": "cloud-alchemists-sandbox",
  | "git_token_secrets_manager_name": "wei-acp-root-token",
  | "cluster_version": "1.12.0-gdce.68",
  | "maintenance_window_start": "",
  | "maintenance_window_end": "",
  | "maintenance_window_recurrence": "",
  | "subnet_vlans": "410",
  | "enable_robin_cns": "true",
  | "zone_name": "us-central1-edge-bjc66013",
  | "labels": ""
  | }
  | },
  | "error": {
  | "code": 2,
  | "message": "[Build: 3c67ed68-16f1-4879-baaa-3a6b4a972825] Failure from gcloud edge-cloud container clusters create command",
  | "details": [
  | {
  | "@type": "type.googleapis.com/google.rpc.ErrorInfo",
  | "reason": "PROVISIONING_FAILED",
  | "domain": "acp.gdc.gke.io",
  | "metadata": {
  | "raw_error": "ERROR: (gcloud.alpha.edge-cloud.container.clusters.create) INVALID_ARGUMENT: version \"1.12.0-gdce.68\" was not found: invalid argument",
  | "diagnostic_output": "",
  | "log_tail": ">>> [Build Step] [Build: 3c67ed68-16f1-4879-baaa-3a6b4a972825] Creating cluster with Robin CNS enabled\n>>> [Zone Signal] Sending 'FACTORY_TURNUP_CHECKS_STARTED' to projects/edgesites-baremetal-lab-qual/locations/us-central1/zones/gmec-bjc90...\n>>> [Zone Signal] Payload: {\n  \"state_signal\": \"FACTORY_TURNUP_CHECKS_STARTED\",\n  \"step\": \">>> [Build Step] [Build: 3c67ed68-16f1-4879-baaa-3a6b4a972825] Creating cluster with Robin CNS enabled\"\n}\n>>> [Zone Signal] Successfully signaled FACTORY_TURNUP_CHECKS_STARTED.\n>>> [Zone Signal] Operation ID: projects/edgesites-baremetal-lab-qual/locations/us-central1/operations/operation-1779139523844-6521e33531858-73813a32-575f3d07\n>>> [Zone Signal] Waiting for operation to complete...\n>>> [Zone Signal] Poll attempt 1/10 - done: true\n>>> [Zone Signal] Operation completed successfully.\n+ ROBIN_CNS_ARG=--enable-robin-cns\n+ GCLOUD_CMD='gcloud alpha'\n+ CMD_ARGS=(edge-cloud container clusters create \"$CLUSTER_NAME\" --control-plane-node-location=\"$NODE_LOCATION\" --control-plane-node-count=\"$NODE_COUNT\" --cluster-ipv4-cidr=\"$CLUSTER_IPV4_CIDR\" --services-ipv4-cidr=\"$SERVICES_IPV4_CIDR\" --external-lb-ipv4-address-pools=\"$EXTERNAL_LOAD_BALANCER_IPV4_ADDRESS_POOLS\" --control-plane-shared-deployment-policy=ALLOWED --location=\"$LOCATION\" --project=\"$FLEET_PROJECT_ID\" --release-channel=NONE --version \"$CLUSTER_VERSION\" --offline-reboot-ttl=7d)\n+ [[ -n --enable-google-group-authentication ]]\n+ CMD_ARGS+=(\"${IDENTITY_SERVICE_ARG}\")\n+ [[ -n --enable-robin-cns ]]\n+ CMD_ARGS+=(\"${ROBIN_CNS_ARG}\")\n+ echo '>>> [Cluster Create] Executing command: gcloud alpha edge-cloud container clusters create wei-acp-dev-cluster --control-plane-node-location=us-central1-edge-bjc66013 --control-plane-node-count=3 --cluster-ipv4-cidr=172.16.0.0/17 --services-ipv4-cidr=192.168.30.0/23 --external-lb-ipv4-address-pools=172.20.100.241-172.20.100.246 --control-plane-shared-deployment-policy=ALLOWED --location=us-central1 --project=cloud-alchemists-sandbox --release-channel=NONE --version 1.12.0-gdce.68 --offline-reboot-ttl=7d --enable-google-group-authentication --enable-robin-cns'\n>>> [Cluster Create] Executing command: gcloud alpha edge-cloud container clusters create wei-acp-dev-cluster --control-plane-node-location=us-central1-edge-bjc66013 --control-plane-node-count=3 --cluster-ipv4-cidr=172.16.0.0/17 --services-ipv4-cidr=192.168.30.0/23 --external-lb-ipv4-address-pools=172.20.100.241-172.20.100.246 --control-plane-shared-deployment-policy=ALLOWED --location=us-central1 --project=cloud-alchemists-sandbox --release-channel=NONE --version 1.12.0-gdce.68 --offline-reboot-ttl=7d --enable-google-group-authentication --enable-robin-cns\n++ gcloud alpha edge-cloud container clusters create wei-acp-dev-cluster --control-plane-node-location=us-central1-edge-bjc66013 --control-plane-node-count=3 --cluster-ipv4-cidr=172.16.0.0/17 --services-ipv4-cidr=192.168.30.0/23 --external-lb-ipv4-address-pools=172.20.100.241-172.20.100.246 --control-plane-shared-deployment-policy=ALLOWED --location=us-central1 --project=cloud-alchemists-sandbox --release-channel=NONE --version 1.12.0-gdce.68 --offline-reboot-ttl=7d --enable-google-group-authentication --enable-robin-cns\n++ tee /dev/fd/5\nERROR: (gcloud.alpha.edge-cloud.container.clusters.create) INVALID_ARGUMENT: version \"1.12.0-gdce.68\" was not found: invalid argument\n+ out='ERROR: (gcloud.alpha.edge-cloud.container.clusters.create) INVALID_ARGUMENT: version \"1.12.0-gdce.68\" was not found: invalid argument'\n+ [[ 1 -ne 0 ]]\n+ die 'Failure from gcloud edge-cloud container clusters create command' 'ERROR: (gcloud.alpha.edge-cloud.container.clusters.create) INVALID_ARGUMENT: version \"1.12.0-gdce.68\" was not found: invalid argument'\n+ [[ '' == \\T\\R\\U\\E ]]\n+ export INSIDE_DIE=TRUE\n+ INSIDE_DIE=TRUE\n+ set +x"
  | }
  | }
  | ]
  | }
  | }
```
HWM API Get Zone State Response:
<img width="1898" height="976" alt="image" src="https://github.com/user-attachments/assets/5723afb9-99ca-49ea-860a-7ec688b99b0b" />


#### Successful Cloud Build Test
Here is the HWM API response when a cloud build succeeded.
```
    {
      "time":  "2026-05-19T06:28:53.758407304Z",
      "type":  "RUNNING",
      "newZoneState":  "FACTORY_CHECKS_STARTED",
      "step":  ">>> [Build Step] [Build: e969ba18-41dc-4eca-85d7-c40ef36ca31c] Beginning provisioning"
    },
    {
      "time":  "2026-05-19T06:28:57.196133901Z",
      "type":  "RUNNING",
      "newZoneState":  "FACTORY_CHECKS_STARTED",
      "step":  ">>> [Build Step] [Build: e969ba18-41dc-4eca-85d7-c40ef36ca31c] Creating cluster with Group RBAC"
    },
    {
      "time":  "2026-05-19T06:28:59.360211993Z",
      "type":  "RUNNING",
      "newZoneState":  "FACTORY_CHECKS_STARTED",
      "step":  ">>> [Build Step] [Build: e969ba18-41dc-4eca-85d7-c40ef36ca31c] Creating cluster with Robin CNS enabled"
    },
    {
      "time":  "2026-05-19T07:12:06.920501129Z",
      "type":  "RUNNING",
      "newZoneState":  "FACTORY_CHECKS_STARTED",
      "step":  ">>> [Build Step] [Build: e969ba18-41dc-4eca-85d7-c40ef36ca31c] All maintenance window fields are not set, skipping"
    },
    {
      "time":  "2026-05-19T07:12:09.349658155Z",
      "type":  "RUNNING",
      "newZoneState":  "FACTORY_CHECKS_STARTED",
      "step":  ">>> [Build Step] [Build: e969ba18-41dc-4eca-85d7-c40ef36ca31c] Initializing zone network"
    },
    {
      "time":  "2026-05-19T07:12:20.331884783Z",
      "type":  "RUNNING",
      "newZoneState":  "FACTORY_CHECKS_STARTED",
      "step":  ">>> [Build Step] [Build: e969ba18-41dc-4eca-85d7-c40ef36ca31c] Configuring zone subnets"
    },
    {
      "time":  "2026-05-19T07:12:37.302565358Z",
      "type":  "RUNNING",
      "newZoneState":  "FACTORY_CHECKS_STARTED",
      "step":  ">>> [Build Step] [Build: e969ba18-41dc-4eca-85d7-c40ef36ca31c] Configuring configsync"
    },
    {
      "time":  "2026-05-19T07:12:55.897597746Z",
      "type":  "RUNNING",
      "newZoneState":  "FACTORY_CHECKS_STARTED",
      "step":  ">>> [Build Step] [Build: e969ba18-41dc-4eca-85d7-c40ef36ca31c] Skipping manual Group RBAC setup"
    },
    {
      "time":  "2026-05-19T07:12:59.048505509Z",
      "type":  "RUNNING",
      "newZoneState":  "FACTORY_CHECKS_STARTED",
      "step":  ">>> [Build Step] [Build: e969ba18-41dc-4eca-85d7-c40ef36ca31c] Waiting for health check resource to be created"
    },
    {
      "time":  "2026-05-19T07:13:19.617429373Z",
      "type":  "RUNNING",
      "newZoneState":  "FACTORY_CHECKS_STARTED",
      "step":  ">>> [Build Step] [Build: e969ba18-41dc-4eca-85d7-c40ef36ca31c] Waiting for platform healthchecks to pass"
    },
    {
      "time":  "2026-05-19T07:24:19.584384154Z",
      "type":  "RUNNING",
      "newZoneState":  "FACTORY_CHECKS_STARTED",
      "step":  ">>> [Build Step] [Build: e969ba18-41dc-4eca-85d7-c40ef36ca31c] Waiting for workload healthchecks to pass"
    },
    {
      "time":  "2026-05-19T07:32:19.793662662Z",
      "type":  "RUNNING",
      "newZoneState":  "FACTORY_CHECKS_STARTED",
      "step":  ">>> [Build Step] [Build: e969ba18-41dc-4eca-85d7-c40ef36ca31c] Waiting 30m before shutting down VMs"
    },
    {
      "time":  "2026-05-19T08:02:21.984608351Z",
      "type":  "RUNNING",
      "newZoneState":  "FACTORY_CHECKS_STARTED",
      "step":  ">>> [Build Step] [Build: e969ba18-41dc-4eca-85d7-c40ef36ca31c] Shutting down running VMs"
    },
    {
      "time":  "2026-05-19T08:02:26.474939245Z",
      "type":  "SUCCESS",
      "newZoneState":  "FACTORY_CHECKS_PASSED"
    }
  ],
```
