### PR TITLE
feat: Break down ConfigSync enablement into granular steps and add timeout

### DIFF
--- a/module/create-cluster.yaml
+++ b/module/create-cluster.yaml
@@ -536,10 +536,11 @@ steps:
     else
       log_build_step "Skipping manual Group RBAC setup"
     fi
+
     set +x +eE
     trap - ERR
 
-    if [ -z "${SKIP_HEALTH_CHECK}" ]; then
+    if [[ -z ${SKIP_HEALTH_CHECK} ]]; then
       # State flag for ConfigSync sequential checks
       config_sync_ok=true
 
@@ -575,8 +576,8 @@ steps:
         else
           # Retrieve Hub API Checkpoint (Start Time) from config-sync annotation
           config_sync_json=$(kubectl get configsyncs.configdelivery.gke.io config-sync -o json 2>/dev/null)
-          creation_time=$(echo "$config_sync_json" | jq -r '.metadata.creationTimestamp' 2>/dev/null)
-          update_time=$(echo "$config_sync_json" | jq -r '.metadata.annotations["configmanagement.gke.io/update-time"]' 2>/dev/null)
+          creation_time=$(printf '%s\n' "$config_sync_json" | jq -r '.metadata.creationTimestamp // empty' 2>/dev/null)
+          update_time=$(printf '%s\n' "$config_sync_json" | jq -r '.metadata.annotations["configmanagement.gke.io/update-time"] // empty' 2>/dev/null)
           log_build_step "ConfigSync custom resource detected (Created: ${creation_time:-unknown}, Hub API Start Time: ${update_time:-unknown})"
         fi
       fi
@@ -596,8 +597,15 @@ steps:
           ((count++))
         done
         if [[ ${count} -ge ${max_retries_for_configsync_healthy} ]]; then
-          log_build_step "[WARNING] ConfigSync custom resource not healthy after 10min. Proceeding to default health checks..."
+          # Extract concise, single-line error messages for HWM telemetry
+          config_sync_err=$(kubectl get configsyncs.configdelivery.gke.io config-sync -o jsonpath='{.status.conditions[?(@.type=="Ready")].message}' 2>/dev/null)
+          root_sync_err=$(kubectl get rootsyncs.configsync.gke.io -n config-management-system root-sync -o jsonpath='{.status.conditions[?(@.status=="True")].message}' 2>/dev/null)
+
+          log_build_step "[WARNING] ConfigSync not healthy. Reason: ${config_sync_err:-unknown}. RootSync Error: ${root_sync_err:-none}. Proceeding to default health checks..."
+          
+          # Dump detailed reports to console for human debugging
           kubectl describe configsyncs.configdelivery.gke.io config-sync 2>/dev/null
+          kubectl describe rootsyncs.configsync.gke.io -n config-management-system root-sync 2>/dev/null
         fi
       fi
 

--- a/module/create-cluster.yaml
+++ b/module/create-cluster.yaml
@@ -536,11 +536,71 @@ steps:
     else
       log_build_step "Skipping manual Group RBAC setup"
     fi
-
     set +x +eE
     trap - ERR
 
     if [ -z "${SKIP_HEALTH_CHECK}" ]; then
+      # State flag for ConfigSync sequential checks
+      config_sync_ok=true
+
+      # Check 1: Check for ConfigSync CRD to be created (Non-blocking telemetry check)
+      count=0
+      max_retries_for_crd_creation=60 # 5 min
+      log_build_step "Waiting for ConfigSync CRD to be created"
+      while [[ ${count} -lt ${max_retries_for_crd_creation} ]]; do
+        kubectl get customresourcedefinitions configsyncs.configdelivery.gke.io >/dev/null 2>&1 && break
+        sleep 5
+        ((count++))
+      done
+
+      if [[ ${count} -ge ${max_retries_for_crd_creation} ]]; then
+        config_sync_ok=false
+        log_build_step "[WARNING] ConfigSync CRD not created after 5min. Proceeding to default health checks..."
+      fi
+
+      # Check 2: Check for ConfigSync custom resource to be created (Non-blocking telemetry check)
+      if [[ "$config_sync_ok" == "true" ]]; then
+        count=0
+        max_retries_for_configsync_creation=60 # 5 min
+        log_build_step "Waiting for ConfigSync custom resource to be created"
+        while [[ ${count} -lt ${max_retries_for_configsync_creation} ]]; do
+          kubectl get configsyncs.configdelivery.gke.io config-sync >/dev/null 2>&1 && break
+          sleep 5
+          ((count++))
+        done
+
+        if [[ ${count} -ge ${max_retries_for_configsync_creation} ]]; then
+          config_sync_ok=false
+          log_build_step "[WARNING] ConfigSync custom resource not created after 5min. Proceeding to default health checks..."
+        else
+          # Retrieve Hub API Checkpoint (Start Time) from config-sync annotation
+          config_sync_json=$(kubectl get configsyncs.configdelivery.gke.io config-sync -o json 2>/dev/null)
+          creation_time=$(echo "$config_sync_json" | jq -r '.metadata.creationTimestamp' 2>/dev/null)
+          update_time=$(echo "$config_sync_json" | jq -r '.metadata.annotations["configmanagement.gke.io/update-time"]' 2>/dev/null)
+          log_build_step "ConfigSync custom resource detected (Created: ${creation_time:-unknown}, Hub API Start Time: ${update_time:-unknown})"
+        fi
+      fi
+
+      # Check 3: Check for ConfigSync custom resource to be healthy (Non-blocking telemetry check)
+      if [[ "$config_sync_ok" == "true" ]]; then
+        count=0
+        max_retries_for_configsync_healthy=120 # 10 min
+        log_build_step "Waiting for ConfigSync custom resource to be healthy"
+        while [[ ${count} -lt ${max_retries_for_configsync_healthy} ]]; do
+          healthy=$(kubectl get configsyncs.configdelivery.gke.io config-sync -o jsonpath='{.status.healthy}' 2>/dev/null)
+          if [[ "$healthy" == "true" ]]; then
+            log_build_step "ConfigSync custom resource is healthy"
+            break
+          fi
+          sleep 5
+          ((count++))
+        done
+        if [[ ${count} -ge ${max_retries_for_configsync_healthy} ]]; then
+          log_build_step "[WARNING] ConfigSync custom resource not healthy after 10min. Proceeding to default health checks..."
+          kubectl describe configsyncs.configdelivery.gke.io config-sync 2>/dev/null
+        fi
+      fi
+
       count=0
       max_retries_for_healthcheck_creation=240 # 1200s/20min
       log_build_step "Waiting for health check resource to be created"


### PR DESCRIPTION
# PR Description

## Overview

It introduces three new, non-blocking validation milestones (Checkpoints) during the ConfigSync enablement phase in the cluster provisioner script (`create-cluster.yaml`). This eliminates the previous "blind wait" during platform health checks and immediately exposes granular telemetry and diagnostics.

## Problem Statement & OMG Incident Context

Previously, during cluster turn-up, the system sat in a single, generic 1-hour wait loop for platform health checks (`PlatformHealthy`). 

During the OMG incident, the in-cluster ConfigSync components (e.g., controllers, webhook, or `reconciler-manager` pods) failed to start. Because the provisioner had no granular milestones, on-call engineers had no visibility into whether the failure was due to a delayed Fleet API request, a Connect Agent connectivity issue, or in-cluster container crash looping. This severely prolonged the Mitigation Time (MTTR) of the incident.

## Proposed Solution: The Three Milestones
This PR inserts three non-blocking, sequential validation checkpoint:

1. **Checkpoint 1: CRD Registration (Timeout: 5 min)**
   * Polls `customresourcedefinitions configsyncs.configdelivery.gke.io` to ensure GKE Hub has successfully registered the CustomResourceDefinition in the cluster.
2. **Checkpoint 2: CR Creation & Metadata Retrieval (Timeout: 5 min)**
   * Polls `configsyncs.configdelivery.gke.io config-sync` to verify GKE Connect applied the bootstrap manifest.
   * Once detected, **automatically extracts and logs two critical timestamps** via `log_build_step`:
     * **Creation Timestamp**: `metadata.creationTimestamp` (CR Creation time)
     * **Hub API Start Time**: `configmanagement.gke.io/update-time` annotation (the exact timestamp GKE Hub started provisioning this feature).
3. **Checkpoint 3: CR Health Check (Timeout: 10 min)**
   * Uses native Kubernetes `jsonpath` to poll `.status.healthy == true` on the `config-sync` Custom Resource.
   * Using native `jsonpath` completely avoids the shell process overhead of piping to `jq` inside a tight loop, making it highly performant.

---

## 🔒 Release Safety & Non-Blocking Design

Since this change is going directly into the upcoming release, **absolute backward compatibility and safety are guaranteed**:

* **Zero Regression Risk**: The checks are wrapped under `set +e` (error-exiting is disabled). No transient cluster error or checkpoint timeout will ever abort or crash the turn-up run.
* **Graceful Fallback**: If any milestone fails or times out, the script prints a clear `[WARNING]` through `log_build_step` (which propagates as a signal to HWM), logs detailed debugging information, and **gracefully falls through to the original, unchanged platform and workload health checks**.
* **Automated Diagnostics**: If Checkpoint 3 (health check) times out, the script automatically executes `kubectl describe configsyncs.configdelivery.gke.io config-sync 2>/dev/null` to dump events, error messages, and conditions straight into the build log. 

## Test
Happy Path:
```
>>> [Build Step] [Build: ff9a5b35-19e4-41d0-9736-d182d7a4a7be] Waiting for ConfigSync CRD to be created
>>> [Build Step] [Build: ff9a5b35-19e4-41d0-9736-d182d7a4a7be] Waiting for ConfigSync custom resource to be created
>>> [Build Step] [Build: ff9a5b35-19e4-41d0-9736-d182d7a4a7be] ConfigSync custom resource detected (Created: 2026-05-26T18:38:55Z, Hub API Start Time: 1779820692)
>>> [Build Step] [Build: ff9a5b35-19e4-41d0-9736-d182d7a4a7be] Waiting for ConfigSync custom resource to be healthy
>>> [Build Step] [Build: ff9a5b35-19e4-41d0-9736-d182d7a4a7be] ConfigSync custom resource is healthy
```
<img width="1153" height="499" alt="image" src="https://github.com/user-attachments/assets/0435a922-c398-442d-a323-a4a5c70d2b9e" />

