### PR TITLE
feat: add GCP API connectivity metrics and alerting policy

### DIFF
--- a/module/alerts.tf
+++ b/module/alerts.tf
@@ -253,3 +253,71 @@ resource "google_monitoring_alert_policy" "config-validation-failed-alert" {
     mime_type = "text/markdown"
   }
 }
+
+resource "google_monitoring_metric_descriptor" "gdc-api-connectivity-descriptor" {
+  description  = "GDC API Connectivity Health Status"
+  display_name = "GDC API Connectivity"
+  type         = "custom.googleapis.com/gdc_api_connectivity"
+  metric_kind  = "GAUGE"
+  value_type   = "INT64"
+  unit         = "1"
+
+  labels {
+    key         = "api"
+    value_type  = "STRING"
+    description = "The API name (e.g. hwm or edgecontainer)"
+  }
+  labels {
+    key         = "project_type"
+    value_type  = "STRING"
+    description = "The target project type (fleet_project or machine_project)"
+  }
+  labels {
+    key         = "target_project_id"
+    value_type  = "STRING"
+    description = "The target project ID"
+  }
+  labels {
+    key         = "location"
+    value_type  = "STRING"
+    description = "The target GCP location"
+  }
+  labels {
+    key         = "failure_reason"
+    value_type  = "STRING"
+    description = "The connection failure reason string"
+  }
+}
+
+resource "google_monitoring_alert_policy" "gdc-api-connectivity-alert" {
+  depends_on = [ google_monitoring_metric_descriptor.gdc-api-connectivity-descriptor ]
+  display_name = "GDC API Connectivity Failure Alert"
+  notification_channels = [google_monitoring_notification_channel.cp_notification_channel.name]
+  combiner = "OR"
+
+  conditions {
+    display_name = "GDC API Connectivity Status is failing (status=0)"
+    condition_threshold {
+      filter     = "metric.type = \"custom.googleapis.com/gdc_api_connectivity\" AND resource.type = \"global\""
+      comparison = "COMPARISON_LT"
+      threshold_value = 1
+      duration   = "1500s" # 25 minutes of continuous failure (at least 2 consecutive runs)
+      
+      trigger {
+        count = 1
+      }
+
+      aggregations {
+        alignment_period   = "1200s"
+        per_series_aligner = "ALIGN_MIN" # If any point is 0 in the period, keep the min (0)
+        cross_series_reducer = "REDUCE_NONE"
+        group_by_fields     = ["metric.label.api", "metric.label.target_project_id", "metric.label.project_type", "metric.label.failure_reason"]
+      }
+    }
+  }
+
+  documentation {
+    content   = "The Cloud Function failed to connect to a GDC Edge API. \n\n**API**: $${metric.label.api}\n**Project Type**: $${metric.label.project_type}\n**Project ID**: $${metric.label.target_project_id}\n**Failure Reason**: $${metric.label.failure_reason}\n\nThis metric has a value of 0, representing a connection failure. Please check the Cloud Function logs and verify credentials, API status, and network routing."
+    mime_type = "text/markdown"
+  }
+}

--- a/module/watchers/src/main.py
+++ b/module/watchers/src/main.py
@@ -73,7 +73,38 @@ def _zone_watcher_worker(
     cb_client = clients.get_cloudbuild_client()
     count = 0
 
-    zones = get_zones(machine_project, location)
+    hwm_status = 1
+    failure_reason = ""
+    try:
+        zones = get_zones(machine_project, location)
+    except Exception as err:
+        logger.exception(
+            "Error listing zones (HWM API) for project: %s, location: %s",
+            machine_project,
+            location,
+        )
+        hwm_status = 0
+        failure_reason = _get_failure_reason(err)
+
+    report_api_connectivity_metric(
+        host_project_id=params.project_id,
+        api="hwm",
+        project_type="machine_project",
+        project_id=machine_project,
+        location=location,
+        status=hwm_status,
+        failure_reason=failure_reason,
+    )
+
+    if hwm_status == 0:
+        thread_end_time = time.perf_counter()
+        logger.error(
+            "Thread zone_watcher(%s, %s) failed because HWM API was unreachable. Took %0.2f seconds",
+            machine_project,
+            location,
+            thread_end_time - thread_start_time,
+        )
+        return 0
 
     for store_id in stores:
         store_info = stores[store_id]
@@ -225,6 +256,8 @@ def zone_watcher(req: flask.Request):
         }
         for future in concurrent.futures.as_completed(machine_futures):
             machine_project, location = machine_futures[future]
+            edgecontainer_status = 1
+            failure_reason = ""
             try:
                 res_pager = future.result()
                 for m in res_pager:
@@ -234,8 +267,23 @@ def zone_watcher(req: flask.Request):
                     else:
                         machine_lists[m.zone].append(m)
             except Exception as err:
-                logger.error(f"Error listing machines for project: {machine_project}, location: {location}")
-                logger.error(err)
+                logger.exception(
+                    "Error listing machines for project: %s, location: %s",
+                    machine_project,
+                    location,
+                )
+                edgecontainer_status = 0
+                failure_reason = _get_failure_reason(err)
+
+            report_api_connectivity_metric(
+                host_project_id=params.project_id,
+                api="edgecontainer",
+                project_type="machine_project",
+                project_id=machine_project,
+                location=location,
+                status=edgecontainer_status,
+                failure_reason=failure_reason,
+            )
 
     count = 0
     unprocessed_zones_lock = threading.Lock()
@@ -283,14 +331,33 @@ def _cluster_watcher_worker(
         parent=ec_client.common_location_path(project_id, location)
     )
     
+    edgecontainer_status = 1
+    failure_reason = ""
     try:
         res_pager_c = ec_client.list_clusters(req_c)
         clusters_by_zone: Dict[str, list[edgecontainer.Cluster]] = defaultdict(list)
         for c in res_pager_c:
             clusters_by_zone[c.control_plane.local.node_location].append(c)
     except Exception as err:
-        logger.error(f"Error listing clusters for project: {project_id}, location: {location}")
-        logger.error(err)
+        logger.exception(
+            "Error listing clusters for project: %s, location: %s",
+            project_id,
+            location,
+        )
+        edgecontainer_status = 0
+        failure_reason = _get_failure_reason(err)
+
+    report_api_connectivity_metric(
+        host_project_id=params.project_id,
+        api="edgecontainer",
+        project_type="fleet_project",
+        project_id=project_id,
+        location=location,
+        status=edgecontainer_status,
+        failure_reason=failure_reason,
+    )
+
+    if edgecontainer_status == 0:
         return 0
 
     for store_id in stores:
@@ -530,6 +597,76 @@ def zone_active_metric(req: flask.Request):
     logger.debug(f'update datapoint for {[x["metric"]["labels"]["store_id"] for x in time_series_data]}')
     logger.debug(f'total zone active flag updated = {len(time_series_data)}')
     return f'total zone active flag updated = {len(time_series_data)}'
+
+
+def _get_failure_reason(err: Exception) -> str:
+    """Determines the failure reason based on exception type."""
+    if isinstance(err, (exceptions.PermissionDenied, exceptions.Unauthenticated)):
+        return "permission_denied"
+    elif isinstance(err, exceptions.InvalidArgument):
+        return "invalid_argument"
+    elif isinstance(err, exceptions.NotFound):
+        return "not_found"
+    elif isinstance(err, exceptions.ResourceExhausted):
+        return "quota_exceeded"
+    return "unreachable"
+
+
+def report_api_connectivity_metric(
+    host_project_id: str,
+    api: str,
+    project_type: str,
+    project_id: str,
+    location: str,
+    status: int,  # 1 for success, 0 for failure
+    failure_reason: str = "",
+):
+    """Reports the API connectivity metric to Cloud Monitoring."""
+    logger.info(
+        "Reporting API connectivity metric: api=%s, project_type=%s, "
+        "project_id=%s, location=%s, status=%d, failure_reason=%s",
+        api,
+        project_type,
+        project_id,
+        location,
+        status,
+        failure_reason,
+    )
+    try:
+        m_client = clients.get_monitoring_client()
+        timestamp = Timestamp()
+        timestamp.GetCurrentTime()
+        data_point = {
+            'interval': {'end_time': timestamp},
+            'value': {'int64_value': status}
+        }
+        time_series_point = {
+            'metric': {
+                'type': 'custom.googleapis.com/gdc_api_connectivity',
+                'labels': {
+                    'api': api,
+                    'project_type': project_type,
+                    'target_project_id': project_id,
+                    'location': location,
+                    'failure_reason': failure_reason,
+                }
+            },
+            'resource': {
+                'type': 'global',
+                'labels': {
+                    'project_id': host_project_id
+                }
+            },
+            'points': [data_point]
+        }
+        request = monitoring_v3.CreateTimeSeriesRequest({
+            'name': f'projects/{host_project_id}',
+            'time_series': [time_series_point]
+        })
+        m_client.create_time_series(request)
+    except Exception as e:
+        logger.error("Failed to report API connectivity metric: %s", e, exc_info=True)
+
 
 def read_intent_data(params, named_key) -> Dict[Tuple, Dict[str, SourceOfTruthModel]]:
     """Returns a data structure containing project, location, and store information  

--- a/module/watchers/tests/test_main.py
+++ b/module/watchers/tests/test_main.py
@@ -77,6 +77,7 @@ class TestMain(unittest.TestCase):
         location = "test-location"
 
         params = mock.MagicMock()
+        params.project_id = "test-host-project"
         params.cloud_build_trigger = "test-trigger"
 
         class MockStore:
@@ -163,3 +164,200 @@ project1,1.11.0
         result = main.read_intent_data(params, 'fleet_project_id')
         
         self.assertEqual(result.get(('project1', 'us-central1')), {})
+
+    def test_get_failure_reason(self):
+        self.assertEqual(main._get_failure_reason(main.exceptions.PermissionDenied("error")), "permission_denied")
+        self.assertEqual(main._get_failure_reason(main.exceptions.Unauthenticated("error")), "permission_denied")
+        self.assertEqual(main._get_failure_reason(main.exceptions.InvalidArgument("error")), "invalid_argument")
+        self.assertEqual(main._get_failure_reason(main.exceptions.NotFound("error")), "not_found")
+        self.assertEqual(main._get_failure_reason(main.exceptions.ResourceExhausted("error")), "quota_exceeded")
+        self.assertEqual(main._get_failure_reason(Exception("generic")), "unreachable")
+
+    @mock.patch('src.main.clients.get_monitoring_client')
+    def test_report_api_connectivity_metric_success(self, mock_get_monitoring_client):
+        mock_m_client = mock.MagicMock()
+        mock_get_monitoring_client.return_value = mock_m_client
+
+        params = mock.MagicMock()
+        params.project_id = "test-host-project"
+
+        main.report_api_connectivity_metric(
+            host_project_id="test-host-project",
+            api="hwm",
+            project_type="machine_project",
+            project_id="mach-proj",
+            location="us-central1",
+            status=1,
+            failure_reason=""
+        )
+
+        mock_m_client.create_time_series.assert_called_once()
+        args, _ = mock_m_client.create_time_series.call_args
+        request = args[0]
+
+        self.assertEqual(request.name, "projects/test-host-project")
+        self.assertEqual(len(request.time_series), 1)
+        ts = request.time_series[0]
+        self.assertEqual(ts.metric.type, "custom.googleapis.com/gdc_api_connectivity")
+        self.assertEqual(ts.metric.labels["api"], "hwm")
+        self.assertEqual(ts.metric.labels["project_type"], "machine_project")
+        self.assertEqual(ts.metric.labels["target_project_id"], "mach-proj")
+        self.assertEqual(ts.metric.labels["location"], "us-central1")
+        self.assertEqual(ts.metric.labels["failure_reason"], "")
+        self.assertEqual(ts.resource.type, "global")
+        self.assertEqual(ts.resource.labels["project_id"], "test-host-project")
+        self.assertEqual(ts.points[0].value.int64_value, 1)
+
+    @mock.patch('src.main.report_api_connectivity_metric')
+    @mock.patch('src.main.get_zones')
+    @mock.patch('src.main.clients.get_cloudbuild_client')
+    def test_zone_watcher_worker_reports_hwm_connectivity_success(
+        self, mock_get_cb, mock_get_zones, mock_report
+    ):
+        mock_get_zones.return_value = {}
+        params = mock.MagicMock()
+        params.project_id = "test-host-project"
+        builds = mock.MagicMock()
+
+        class MockStore:
+            fleet_project_id = "fleet-proj-1"
+            intent_hash = "hash-1"
+
+        stores = {"store1": MockStore()}
+
+        main._zone_watcher_worker(
+            machine_project="mach-proj",
+            location="us-central1",
+            stores=stores,
+            params=params,
+            builds=builds,
+            machine_lists={},
+            unprocessed_zones={},
+            unprocessed_zones_lock=mock.MagicMock(),
+        )
+
+        mock_report.assert_called_once_with(
+            host_project_id="test-host-project",
+            api="hwm",
+            project_type="machine_project",
+            project_id="mach-proj",
+            location="us-central1",
+            status=1,
+            failure_reason=""
+        )
+
+    @mock.patch('src.main.report_api_connectivity_metric')
+    @mock.patch('src.main.get_zones')
+    @mock.patch('src.main.clients.get_cloudbuild_client')
+    def test_zone_watcher_worker_reports_hwm_connectivity_failure(
+        self, mock_get_cb, mock_get_zones, mock_report
+    ):
+        mock_get_zones.side_effect = Exception("HWM API Connection Failed")
+        params = mock.MagicMock()
+        params.project_id = "test-host-project"
+        builds = mock.MagicMock()
+
+        class MockStore:
+            fleet_project_id = "fleet-proj-1"
+            intent_hash = "hash-1"
+
+        stores = {"store1": MockStore()}
+
+        result = main._zone_watcher_worker(
+            machine_project="mach-proj",
+            location="us-central1",
+            stores=stores,
+            params=params,
+            builds=builds,
+            machine_lists={},
+            unprocessed_zones={},
+            unprocessed_zones_lock=mock.MagicMock(),
+        )
+
+        self.assertEqual(result, 0)
+        mock_report.assert_called_once_with(
+            host_project_id="test-host-project",
+            api="hwm",
+            project_type="machine_project",
+            project_id="mach-proj",
+            location="us-central1",
+            status=0,
+            failure_reason="unreachable"
+        )
+
+    @mock.patch('src.main.report_api_connectivity_metric')
+    @mock.patch('src.main.get_memberships')
+    @mock.patch('src.main.get_zones')
+    @mock.patch('src.main.clients.get_edgecontainer_client')
+    @mock.patch('src.main.clients.get_cloudbuild_client')
+    def test_cluster_watcher_worker_reports_metrics_success(
+        self, mock_get_cb, mock_get_ec, mock_get_zones, mock_get_memberships, mock_report
+    ):
+        mock_get_memberships.return_value = {}
+        mock_get_zones.return_value = {}
+        
+        mock_ec_client = mock.MagicMock()
+        mock_get_ec.return_value = mock_ec_client
+        mock_ec_client.list_clusters.return_value = []
+        mock_ec_client.common_location_path.return_value = "path"
+
+        class MockStore:
+            fleet_project_id = "fleet-proj-1"
+            machine_project_id = "mach-proj-1"
+            location = "us-central1"
+
+        stores = {"store1": MockStore()}
+        params = mock.MagicMock()
+        params.project_id = "test-host-project"
+
+        main._cluster_watcher_worker("fleet-proj-1", "us-central1", stores, params)
+
+        # Assert report call for edgecontainer connectivity status=1 (HWM is not reported by cluster_watcher)
+        mock_report.assert_called_once_with(
+            host_project_id="test-host-project",
+            api="edgecontainer",
+            project_type="fleet_project",
+            project_id="fleet-proj-1",
+            location="us-central1",
+            status=1,
+            failure_reason=""
+        )
+
+    @mock.patch('src.main.report_api_connectivity_metric')
+    @mock.patch('src.main.get_memberships')
+    @mock.patch('src.main.get_zones')
+    @mock.patch('src.main.clients.get_edgecontainer_client')
+    @mock.patch('src.main.clients.get_cloudbuild_client')
+    def test_cluster_watcher_worker_reports_metrics_failure(
+        self, mock_get_cb, mock_get_ec, mock_get_zones, mock_get_memberships, mock_report
+    ):
+        mock_get_memberships.return_value = {}
+        mock_get_zones.return_value = {}
+        
+        mock_ec_client = mock.MagicMock()
+        mock_get_ec.return_value = mock_ec_client
+        # Edgecontainer API fails
+        mock_ec_client.list_clusters.side_effect = Exception("EdgeContainer API down")
+        mock_ec_client.common_location_path.return_value = "path"
+
+        class MockStore:
+            fleet_project_id = "fleet-proj-1"
+            machine_project_id = "mach-proj-1"
+            location = "us-central1"
+
+        stores = {"store1": MockStore()}
+        params = mock.MagicMock()
+        params.project_id = "test-host-project"
+
+        main._cluster_watcher_worker("fleet-proj-1", "us-central1", stores, params)
+
+        # Assert report call for edgecontainer status=0
+        mock_report.assert_called_once_with(
+            host_project_id="test-host-project",
+            api="edgecontainer",
+            project_type="fleet_project",
+            project_id="fleet-proj-1",
+            location="us-central1",
+            status=0,
+            failure_reason="unreachable"
+        )


### PR DESCRIPTION
Introduces `custom.googleapis.com/gdc_api_connectivity` metric inside `zone_watcher` and `cluster_watcher` to report their connection status to the APIs (HWM and EdgeContainer) of the fleet project and the machine project.

Also features SRE-friendly failure classification labels and custom Terraform Alerting Policy with a 25-minute duration window to filter transient glitches.

Tested by manual deployment:
<img width="1029" height="443" alt="image" src="https://github.com/user-attachments/assets/27ba52ce-b6ea-47f8-a925-a73e298990d2" />
<img width="1278" height="764" alt="image" src="https://github.com/user-attachments/assets/9d38d38c-9afe-4b04-ab28-69fd940f0cac" />

