### PR TITLE
fix: suppress red herring csvtool error for missing optional columns

### DIFF
--- a/module/create-cluster.yaml
+++ b/module/create-cluster.yaml
@@ -326,7 +326,13 @@ steps:
       input="$1"
       column="$2"
 
-      output=$(echo "$input" | csvtool namedcol "$column" - | csvtool drop 1 - | tr -d '"')
+      local raw_col
+      if ! raw_col=$(echo "$input" | csvtool namedcol "$column" - 2>/dev/null); then
+        echo ">>> [Config] [WARNING] Optional column '$column' not found in CSV intent. Skipping." >&2
+        return 0
+      fi
+
+      output=$(echo "$raw_col" | csvtool drop 1 - | tr -d '"')
 
       echo "$output"
     }

--- a/module/modify-cluster.yaml
+++ b/module/modify-cluster.yaml
@@ -50,7 +50,13 @@ steps:
       input="$1"
       column="$2"
 
-      output=$(echo "$input" | csvtool namedcol "$column" - | csvtool drop 1 - | tr -d '"')
+      local raw_col
+      if ! raw_col=$(echo "$input" | csvtool namedcol "$column" - 2>/dev/null); then
+        echo ">>> [Config] [WARNING] Optional column '$column' not found in CSV intent. Skipping." >&2
+        return 0
+      fi
+
+      output=$(echo "$raw_col" | csvtool drop 1 - | tr -d '"')
 
       echo "$output"
     }


### PR DESCRIPTION
Suppress the ugly OCaml exception stderr output when optional columns (e.g. 'labels') are missing from the cluster intent CSV file. Instead, check for the column's presence using csvtool and print a clean warning to stderr.

Bug: b/488163007