### PR TITLE
Change log message when zone signaling is disabled

### DIFF
--- a/module/create-cluster.yaml
+++ b/module/create-cluster.yaml
@@ -138,7 +138,7 @@ steps:
       [[ -z "${zone_store_path}" ]] && { echo ">>> [Zone Signal] zone_store_path not provided"; return ; }
 
       if [[ "$UNDER_FACTORY_CHECKS" == "FALSE" ]]; then
-        echo ">>> [Zone Signal] Aborted: UNDER_FACTORY_CHECKS is FALSE"
+        echo ">>> [Zone Signal] Skipped: UNDER_FACTORY_CHECKS is FALSE"
         return;
       fi
 


### PR DESCRIPTION
Zone signaling should be disabled in situations where reprovisioning occurs (which occurs often in labs). I adjusted the log message so it reflects as an expected condition vs. an unexpected one. I think this will reduce confusion as users are scanning logs. 