### PR TITLE
Add trap for log file async tee process in create-cluster.yaml

### DIFF
--- a/module/create-cluster.yaml
+++ b/module/create-cluster.yaml
@@ -25,6 +25,9 @@ steps:
     # Capture all output to a file for log_tail in case of failure
     LOG_FILE="/tmp/acp_execution_create_cluster_${BUILD_ID}.log"
     exec > >(tee -a "$LOG_FILE") 2>&1
+    # Give the async tee process time to drain the pipe before container teardown,
+    # otherwise output written just before exit is lost from Cloud Build logs.
+    trap 'sleep 5' EXIT
 
     HARDWARE_MANAGEMENT_API_ENDPOINT="https://gdchardwaremanagement.googleapis.com"
     if [[ -n "${HARDWARE_MANAGEMENT_API_ENDPOINT_OVERRIDE}" ]]; then


### PR DESCRIPTION
Added a trap command to ensure the async tee process has time to flush output before container teardown.

This PR is for fixing issue in #71 . 