### PR TITLE
[ACP 1.5.x] Fix zone_signal arithmetic crash and mute telemetry error

### DIFF
--- a/module/create-cluster.yaml
+++ b/module/create-cluster.yaml
@@ -80,7 +80,7 @@ steps:
       message=">>> [Build Step] [Build: ${BUILD_ID}] $*"
       echo "$message"
 
-      zone_signal "$ZONE_ID" FACTORY_TURNUP_CHECKS_STARTED "$message"
+      zone_signal "$ZONE_ID" FACTORY_TURNUP_CHECKS_STARTED "$message" || true
     )
 
     # Sets the `UNDER_FACTORY_CHECKS` to either true if ZoneState is ready, started, or failed
@@ -294,7 +294,7 @@ steps:
         
         [[ "${is_completed}" != "false" ]] && break
         sleep 5
-        ((signal_attempts++))
+        ((++signal_attempts))
       done
       
       if [[ ${signal_attempts} -ge ${max_retries_for_signal_completion} ]]; then


### PR DESCRIPTION
Script enhancements to fix silent script terminations occurring during latency polling loops or when strict error traps (set -eE) are triggered in auxiliary logging pipelines (particularly observed during Full Cluster Repair (FCR)).

- Change post-increment ((signal_attempts++)) to pre-increment ((++signal_attempts)) to avoid evaluating to 0 and triggering exit code 1 under strict error checking.
- Append || true in log_build_step to prevent auxiliary telemetry failures from halting provisioning.

Bug: b/538240987
Related: b/537814308