### PR TITLE
Fix stderr pollution in gcloud data captures

### DIFF
--- a/module/create-cluster.yaml
+++ b/module/create-cluster.yaml
@@ -104,7 +104,7 @@ steps:
       set -x
 
       if [[ $curl_status -ne 0 ]]; then
-        die "Failed to query the zone state" "$out" 14
+        die "Failed to query the zone state" "$zone_response" 14
       fi
 
       local zone_state=$(printf '%s\n' "$zone_response" | jq -r '.state // empty' 2>/dev/null)
@@ -602,7 +602,7 @@ steps:
     for vlan in $(echo $SUBNET_VLANS | csvtool transpose -); do
       EXISTING_VLAN=$(gcloud edge-cloud networking subnets list --location $LOCATION \
           --zone $NODE_LOCATION --project $MACHINE_PROJECT_ID \
-          --filter="VLANID=$vlan" --format="json" 2>&1)
+          --filter="VLANID=$vlan" --format="json")
 
       [[ $? -ne 0 ]] && die "Unable to query for subnets" "$EXISTING_VLAN" 7
 
@@ -699,7 +699,7 @@ steps:
     fi
 
     out=$(gcloud storage cp gs://$CLUSTER_INTENT_BUCKET/fleet-packages-rbac.yaml.template . 2>&1) || die "Failed to copy fleet packages RBAC template" "$out"
-    PROJECT_NUMBER_RESOLVED=$(gcloud projects describe $FLEET_PROJECT_ID --format="value(projectNumber)" 2>&1) || die "Failed to describe project" "$PROJECT_NUMBER_RESOLVED"
+    PROJECT_NUMBER_RESOLVED=$(gcloud projects describe $FLEET_PROJECT_ID --format="value(projectNumber)") || die "Failed to describe project" "$PROJECT_NUMBER_RESOLVED"
     export PROJECT_NUMBER="$PROJECT_NUMBER_RESOLVED"
     
     out=$(envsubst < fleet-packages-rbac.yaml.template > fleet-packages-rbac.yaml 2>&1) || die "Failed to substitute environment variables in template" "$out"
@@ -727,7 +727,7 @@ steps:
     # Apply old Group RBAC steps if cluster version is less than 1.10.0
     if [[ "${SKIP_IDENTITY_SERVICE}" == "FALSE" ]] &&  ! gdc_version_evaluate "${CLUSTER_VERSION}" "1.10.0"; then
       log_build_step "Configuring manual Group RBAC"
-      FLEET_PROJECT_NUMBER=$(gcloud projects describe $FLEET_PROJECT_ID --format='value(projectNumber)' 2>&1) || die "Failed to describe project for Group RBAC" "$FLEET_PROJECT_NUMBER"
+      FLEET_PROJECT_NUMBER=$(gcloud projects describe $FLEET_PROJECT_ID --format='value(projectNumber)') || die "Failed to describe project for Group RBAC" "$FLEET_PROJECT_NUMBER"
       out=$(kubectl patch clientconfig default -n kube-public --type=merge -p '{"spec":{"authentication":[{"google":{"audiences":["//'${GKEHUB_API_ENDPOINT}'/projects/'${FLEET_PROJECT_NUMBER}'/locations/global/memberships/'${CLUSTER_NAME}'"]},"name":"google-authentication-method"}]}}' 2>&1) || {
         diag=$(
           kubectl get clientconfig default -n kube-public -o json 2>/dev/null | jq '


### PR DESCRIPTION
**Affected versions:** v1.5.0, v1.5.1

**Not affected:** v1.4.0 and earlier

**File:** `module/create-cluster.yaml` — "Configuring zone subnets" step

---
## Summary

In v1.5.0 a `2>&1` was added to the `gcloud edge-cloud networking subnets list` call whose output is used to decide whether a VLAN already exists. That merges gcloud's **stderr** into the variable that is then compared with the exact string `"[]"`.

On a freshly turned-up zone (zero subnets) gcloud writes a warning to stderr, so the captured value is `"WARNING: ...\n[]"` rather than `"[]"`. The equality test fails, the script takes the `else` branch, logs `VLAN <n> already exists`, and **skips subnet creation entirely**.

The bug only manifests when the VLAN genuinely does *not* exist — i.e. precisely in the case where creation is required. When a matching subnet does exist, gcloud returns a non-empty JSON array with no warning and the `!= "[]"` test is accidentally correct. Hence the observable behaviour is "the check always says the VLAN already exists".

The `2>&1` appears to have been added so that `$EXISTING_VLAN` would carry gcloud's error text into the structured failure signal:

```bash
[[ $? -ne 0 ]] && die "Unable to query for subnets" "$EXISTING_VLAN" 7
```

The unintended consequence is that the *same* variable also carries stderr on the **success** path, where it is used as data.

## Reproduction

Any zone with no subnets yet:

```console
$ gcloud edge-cloud networking subnets list \
    --location=australia-southeast1 \
    --zone=australia-southeast1-edge-xxxxxxx \
    --project=<machine_project_id> \
    --filter="VLANID=410" \
    --format="json" 2>&1
WARNING: The following filter keys were not present in any resource : vlanId
[]
```

`$EXISTING_VLAN` is therefore `"WARNING: The following filter keys were not present in any resource : vlanId\n[]"`, and:

```bash
[ "$EXISTING_VLAN" = "[]" ]   # false
```

Note the warning echoes the key back as `vlanId`, confirming gcloud normalises `VLANID` correctly — the filter key name is **not** the problem.

## Impact

1. The cluster is created successfully, but the subnets declared in `subnet_vlans` are never created.
2. Workloads that depend on those VLANs never become healthy, so the build eventually fails at the workload health check and emits `cluster-creation-failure-healthcheck-${environment}`.
3. The zone is signalled `FACTORY_TURNUP_CHECKS_FAILED`, requiring manual intervention.

## Two further instances of the same pattern (latent)

The same "capture stderr into a variable whose *value* is consumed" pattern exists in two more places. Neither is currently known to misfire, but both are one gcloud warning away from silent corruption, and `|| die` does not protect them because it only triggers on a non-zero exit code:

**1. `module/create-cluster.yaml` — `PROJECT_NUMBER`**

```bash
PROJECT_NUMBER_RESOLVED=$(gcloud projects describe $FLEET_PROJECT_ID --format="value(projectNumber)" 2>&1) || die ...
export PROJECT_NUMBER="$PROJECT_NUMBER_RESOLVED"
```

`PROJECT_NUMBER` is consumed by `envsubst` when rendering `fleet-packages-rbac.yaml.template`. Any warning on stderr is baked into the rendered RBAC manifest.

**2. `module/create-cluster.yaml` — `FLEET_PROJECT_NUMBER` (Group RBAC path, cluster version < 1.10.0)**

```bash
FLEET_PROJECT_NUMBER=$(gcloud projects describe $FLEET_PROJECT_ID --format='value(projectNumber)' 2>&1) || die ...
kubectl patch clientconfig default ... "audiences":["//${GKEHUB_API_ENDPOINT}/projects/${FLEET_PROJECT_NUMBER}/locations/global/memberships/${CLUSTER_NAME}"] ...
```

A polluted value produces a malformed audience URL and breaks Google Group authentication.

For what it's worth, this class of bug was already recognised elsewhere in the same file — `parse_csv_required` / `parse_csv_optional` route their `die` calls to stderr (`... 3 >&2`) precisely so the message is not captured by the enclosing command substitution. The three sites above were missed.