### PR TITLE
Grant roles/monitoring.metricWriter to zone-watcher-agent in host project

### DIFF
--- a/module/main.tf
+++ b/module/main.tf
@@ -233,6 +233,7 @@ resource "google_service_account" "zone-watcher-agent" {
 resource "google_project_iam_member" "zone-watcher-agent-run-roles" {
   for_each = toset([
     "roles/cloudbuild.builds.editor",
+    "roles/monitoring.metricWriter",
   ])
 
   project = var.project_id


### PR DESCRIPTION
### Description
Grant `roles/monitoring.metricWriter` to `zone-watcher-agent` in the host project (`var.project_id`).

### Rationale
In ACP 1.5.0+, `cluster-watcher` and `zone-watcher` call `report_api_connectivity_metric` to report custom API connectivity metrics (`custom.googleapis.com/gdc_api_connectivity`) to Cloud Monitoring in the host project.

Without `roles/monitoring.metricWriter` on `var.project_id`, `zone-watcher-agent` encounters:
`google.api_core.exceptions.PermissionDenied: 403 Permission monitoring.timeSeries.create denied (or the resource may not exist)`

Adding `roles/monitoring.metricWriter` resolves this permission issue and allows metric creation.

Bug: b/547999775